### PR TITLE
Added -fPIC flag to Linux builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,3 +22,6 @@ add_library (SQLiteCpp
  Transaction.cpp
  Transaction.h
 )
+if(LINUX AND (CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
+    set_target_properties(SQLiteCpp PROPERTIES COMPILE_FLAGS "-fPIC")
+endif(LINUX AND (CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))


### PR DESCRIPTION
- When linking a shared library against SQLiteCpp, GCC/Clang throws a relocation error
