### PR TITLE
Fix for clang warning about Column's implicit constructor.

### DIFF
--- a/include/SQLiteCpp/Column.h
+++ b/include/SQLiteCpp/Column.h
@@ -43,6 +43,13 @@ namespace SQLite
 class Column
 {
 public:
+    // Make clang happy by explicitly implementing the copy-constructor:
+    Column(const Column & aOther) :
+        mStmtPtr(aOther.mStmtPtr),
+        mIndex(aOther.mIndex)
+    {
+    }
+    
     /**
      * @brief Encapsulation of a Column in a Row of the result.
      *


### PR DESCRIPTION
Without this, clang complains when compiling in C++11 mode:

> definition of implicit copy constructor for 'Column' is deprecated because it has a user-declared destructor [-Wdeprecated]
