### PR TITLE
Statement now stores the status of the last operation.

### DIFF
--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -362,14 +362,14 @@ public:
             return mpStmt;
         }
 
-        int getLastStatus () const
+        int getLastStatus() const
         {
-          return mLastStatus ;
+          return mLastStatus;
         }
 
-        void setLastStatus (int status)
+        void setLastStatus(int status)
         {
-          mLastStatus = status ;
+          mLastStatus = status;
         }
 
     private:
@@ -378,11 +378,11 @@ public:
         /// @}
 
     private:
-        sqlite3*        mpSQLite;   //!< Pointer to SQLite Database Connection Handle
-        sqlite3_stmt*   mpStmt;     //!< Pointer to SQLite Statement Object
-        unsigned int*   mpRefCount; //!< Pointer to the heap allocated reference counter of the sqlite3_stmt
-                                    //!< (to share it with Column objects)
-        int             mLastStatus;//!< The return status of the last statement evaluation
+        sqlite3*        mpSQLite;    //!< Pointer to SQLite Database Connection Handle
+        sqlite3_stmt*   mpStmt;      //!< Pointer to SQLite Statement Object
+        unsigned int*   mpRefCount;  //!< Pointer to the heap allocated reference counter of the sqlite3_stmt
+                                     //!< (to share it with Column objects)
+        int             mLastStatus; //!< The return status of the last statement evaluation
     };
 
 private:

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -181,8 +181,8 @@ bool Statement::executeStep()
 {
     if (false == mbDone)
     {
-        int ret = sqlite3_step(mStmtPtr) ;
-        mStmtPtr.setLastStatus (ret);
+        int ret = sqlite3_step(mStmtPtr);
+        mStmtPtr.setLastStatus(ret);
         if (SQLITE_ROW == ret) // one row is ready : call getColumn(N) to access it
         {
             mbOk = true;
@@ -213,7 +213,7 @@ int Statement::exec()
     if (false == mbDone)
     {
         int ret = sqlite3_step(mStmtPtr);
-        mStmtPtr.setLastStatus (ret);
+        mStmtPtr.setLastStatus(ret);
         if (SQLITE_DONE == ret) // the statement has finished executing successfully
         {
             mbOk = false;
@@ -276,7 +276,7 @@ bool Statement::isColumnNull(const int aIndex) const
 // Check if aRet equal SQLITE_OK, else throw a SQLite::Exception with the SQLite error message
 void Statement::check(const int aRet)
 {
-    mStmtPtr.setLastStatus (aRet) ;
+    mStmtPtr.setLastStatus(aRet);
     if (SQLITE_OK != aRet)
     {
         throw SQLite::Exception(sqlite3_errmsg(mStmtPtr));
@@ -346,7 +346,8 @@ Statement::Ptr::~Ptr() noexcept // nothrow
         // as no Statement not Column objet use it anymore
         int ret = sqlite3_finalize(mpStmt);
         // Never throw an exception in a destructor
-        SQLITECPP_ASSERT((SQLITE_OK == ret || mLastStatus == ret), sqlite3_errmsg(mpSQLite));  // See SQLITECPP_ENABLE_ASSERT_HANDLER
+        SQLITECPP_ASSERT((SQLITE_OK == ret || mLastStatus == ret),
+          sqlite3_errmsg(mpSQLite));  // See SQLITECPP_ENABLE_ASSERT_HANDLER
 
         // and delete the reference counter
         delete mpRefCount;


### PR DESCRIPTION
I've added mLastStatus to the pointer class and set it during statement operations. So the pointer destructor can check the return result of finalize against the last statement status. It then only asserts if there is an error and it is different to the last statement error
