### PR TITLE
Change paths in example1 to absolute

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,11 +160,14 @@ endif (WIN32)
 
 option(SQLITECPP_RUN_CPPLINT "Run cpplint.py tool for Google C++ StyleGuide." ON)
 if (SQLITECPP_RUN_CPPLINT)
-    # add a cpplint target to the "all" target
-    add_custom_target(SQLiteCpp_cpplint
-     ALL
-     COMMAND python ${PROJECT_SOURCE_DIR}/cpplint.py ${CPPLINT_ARG_OUTPUT} ${CPPLINT_ARG_VERBOSE} ${CPPLINT_ARG_LINELENGTH} ${SQLITECPP_SRC} ${SQLITECPP_INC}
-    )
+    find_package(PythonLibs)
+    if (PYTHONLIBS_FOUND)
+        # add a cpplint target to the "all" target
+        add_custom_target(SQLiteCpp_cpplint
+         ALL
+         COMMAND python ${PROJECT_SOURCE_DIR}/cpplint.py ${CPPLINT_ARG_OUTPUT} ${CPPLINT_ARG_VERBOSE} ${CPPLINT_ARG_LINELENGTH} ${SQLITECPP_SRC} ${SQLITECPP_INC}
+        )
+    endif (PYTHONLIBS_FOUND)
 else (SQLITECPP_RUN_CPPLINT)
     message(STATUS "SQLITECPP_RUN_CPPLINT OFF")
 endif (SQLITECPP_RUN_CPPLINT)
@@ -179,7 +182,7 @@ if (SQLITECPP_RUN_CPPCHECK)
         COMMAND cppcheck -j 4 cppcheck --enable=style --quiet ${CPPCHECK_ARG_TEMPLATE} ${PROJECT_SOURCE_DIR}/src
        )
     else (CPPCHECK_EXECUTABLE)
-        message(STATUS "cppcheck not found")
+        message(STATUS "Could NOT find cppcheck")
     endif (CPPCHECK_EXECUTABLE)
 else (SQLITECPP_RUN_CPPCHECK)
     message(STATUS "SQLITECPP_RUN_CPPCHECK OFF")
@@ -195,8 +198,6 @@ if (SQLITECPP_RUN_DOXYGEN)
          COMMAND doxygen Doxyfile > ${DEV_NULL}
          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         )
-    else (DOXYGEN_FOUND)
-        message(STATUS "Doxygen not found")
     endif (DOXYGEN_FOUND)
 else (SQLITECPP_RUN_DOXYGEN)
     message(STATUS "SQLITECPP_RUN_DOXYGEN OFF")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,9 +139,9 @@ include_directories("${PROJECT_SOURCE_DIR}/include")
 # add sources of the wrapper as a "SQLiteCpp" static library
 add_library(SQLiteCpp ${SQLITECPP_SRC} ${SQLITECPP_INC} ${SQLITECPP_DOC} ${SQLITECPP_SCRIPT})
 
-if (UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
+if (UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))
     set_target_properties(SQLiteCpp PROPERTIES COMPILE_FLAGS "-fPIC")
-endif (UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
+endif (UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))
 
 
 # SQLite3 library (Windows only)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,17 @@
 if (BIICODE)
 
-  include(${CMAKE_HOME_DIRECTORY}/biicode.cmake)
-  # Initializes block variables
-  INIT_BIICODE_BLOCK()
-
+  # biicode doesn't process files bigger than 5Mb
+  list(APPEND BII_LIB_SRC sqlite3/sqlite3.c)
   # Include base block dir
   ADD_BIICODE_TARGETS()
-  
-  # Link target with dl for linux
-  IF (UNIX)
-   IF(NOT APPLE)
-     TARGET_LINK_LIBRARIES(${BII_BLOCK_TARGET} INTERFACE dl)
-   ENDIF()
-  ENDIF()  
 
+  # Link target with dl for linux
+  if (UNIX)
+   TARGET_LINK_LIBRARIES(${BII_BLOCK_TARGET} INTERFACE pthread)
+   if(NOT APPLE)
+     TARGET_LINK_LIBRARIES(${BII_BLOCK_TARGET} INTERFACE dl)
+   endif()
+  endif()  
 else (BIICODE)
 
 # Main CMake file for compiling the library itself, examples and tests.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ SQLiteC++
 
 [![Travis CI Linux Build Status](https://travis-ci.org/SRombauts/SQLiteCpp.svg)](https://travis-ci.org/SRombauts/SQLiteCpp "Travis CI Linux Build Status")
 [![AppVeyor Windows Build status](https://ci.appveyor.com/api/projects/status/github/SRombauts/SQLiteCpp?svg=true)](https://ci.appveyor.com/project/SbastienRombauts/SQLiteCpp "AppVeyor Windows Build status")
+[![Build Status](https://webapi.biicode.com/v1/badges/sqlite/sqlite/sqlite/master)](https://www.biicode.com/sqlite/sqlite) 
+
 
 SQLiteC++ (SQLiteCpp) is a smart and easy to use C++ SQLite3 wrapper.
 

--- a/biicode.conf
+++ b/biicode.conf
@@ -20,7 +20,6 @@
     # Manual adjust file implicit dependencies, add (+), remove (-), or overwrite (=)
     include/SQLiteCpp/Assertion.h - tests/Database_test.cpp
     include/SQLiteCpp/Assertion.h - examples/example1/main.cpp
-    include/SQLiteCpp/Assertion.h - examples/example1/biimain.cpp
 
 [mains]
     # Manual adjust of files that define an executable
@@ -42,4 +41,3 @@
     # By default they are copied to bin/user/block/... which should be taken into account
     # when loading from disk such data
     examples/example1/main.cpp + example.db3 logo.png
-    examples/example1/biimain.cpp + example.db3 logo.png

--- a/examples/example1/main.cpp
+++ b/examples/example1/main.cpp
@@ -13,8 +13,7 @@
 #include <iostream>
 #include <cstdio>
 #include <cstdlib>
-#include <cstdlib>
-
+#include <string>
 
 #include <SQLiteCpp/SQLiteCpp.h>
 
@@ -31,10 +30,17 @@ void assertion_failed(const char* apFile, const long apLine, const char* apFunc,
 }
 #endif
 
+/// Get example path
+static inline std::string getExamplePath()
+{
+    std::string filePath(__FILE__);
+    return filePath.substr( 0, filePath.length() - std::string("main.cpp").length());
+}
+
 /// Example Database
-static const char* filename_example_db3 = "examples/example1/example.db3";
+static const std::string filename_example_db3 = getExamplePath() + "/example.db3";
 /// Image
-static const char* filename_logo_png    = "examples/example1/logo.png";
+static const std::string filename_logo_png    = getExamplePath() + "/logo.png";
 
 
 /// Object Oriented Basic example
@@ -307,7 +313,7 @@ int main ()
         db.exec("DROP TABLE IF EXISTS test");
         db.exec("CREATE TABLE test (id INTEGER PRIMARY KEY, value BLOB)");
 
-        FILE* fp = fopen(filename_logo_png, "rb");
+        FILE* fp = fopen(filename_logo_png.c_str(), "rb");
         if (NULL != fp)
         {
             char  buffer[16*1024];


### PR DESCRIPTION
Hi,

After constantly seeing the example failing when I run make test, I decided to try and fix it. I've now added a little helper function that returns the absolute path to the example1 sub-directory. This is then tagged onto the filenames for the db and logo, so that they can be referenced in an absolute sense.

Works for me on Mac OS X 10.10 and Ubuntu 14.04.

Hope this is useful.