### PR TITLE
Use sqlite_errstr instead of sqlite3_errmsg

### DIFF
--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -74,7 +74,7 @@ Database::~Database() noexcept // nothrow
 {
     const int ret = sqlite3_close(mpSQLite);
     // Never throw an exception in a destructor
-    SQLITECPP_ASSERT(SQLITE_OK == ret, sqlite3_errmsg(mpSQLite));  // See SQLITECPP_ENABLE_ASSERT_HANDLER
+    SQLITECPP_ASSERT(SQLITE_OK == ret, sqlite3_errstr(ret));  // See SQLITECPP_ENABLE_ASSERT_HANDLER
 }
 
 /**


### PR DESCRIPTION
mpSQLite is free'd with sqlite3_close. It's no more accesible.
Fixes: #48