### PR TITLE
Added support for extension loading

### DIFF
--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -336,6 +336,25 @@ public:
                               apApp, apFunc, apStep, apFinal, apDestroy);
     }
 
+
+    /**
+     * @brief Load a module into the current sqlite database instance. 
+     *
+     *  This is the equivalent of the sqlite3_load_extension call, but additionally enables
+     *  module loading support prior to loading the requested module.
+     *
+     * @see http://www.sqlite.org/c3ref/load_extension.html
+     *
+     * @note UTF-8 text encoding assumed.
+     *
+     * @param[in] apExtensionName   Name of the shared library containing extension
+     * @param[in] apEntryPointName  Name of the entry point (NULL to let sqlite work it out)
+     *
+     * @throw SQLite::Exception in case of error
+     */
+    void loadExtension(const char* apExtensionName,
+         const char *apEntryPointName);
+
 private:
     /// @{ Database must be non-copyable
     Database(const Database&);

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -151,5 +151,18 @@ void Database::createFunction(const char*   apFuncName,
     check(ret);
 }
 
+// Load an extension into the sqlite database. Only affects the current connection.
+// Parameter details can be found here: http://www.sqlite.org/c3ref/load_extension.html
+void Database::loadExtension(const char* apExtensionName,
+         const char *apEntryPointName)
+{
+    int ret = sqlite3_enable_load_extension(mpSQLite, 1);
+
+    check(ret);
+
+    ret = sqlite3_load_extension(mpSQLite, apExtensionName, apEntryPointName, 0);
+
+    check(ret);
+}
 
 }  // namespace SQLite


### PR DESCRIPTION
I have added this to the loadExtension to Database class as preferred.

It passes all your existing unit tests, but doesn't have an explicit unit test, since this would require a dummy module to be added to the source base, which I didn't think was a good idea!

I have however tested against my application and it successfully loads and integrates a module into SQLite3.