### PR TITLE
Build as dll

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,16 @@ project(SQLiteCpp)
 if (WIN32)
     set(DEV_NULL                "NUL")
     # build the SQLite3 C library for Windows (for ease of use)
-    set(SQLITECPP_INTERNAL_SQLITE_DEFAULT     ON)
-    set(SQLITE_ENABLE_COLUMN_METADATA_DEFAULT ON)
+    set(SQLITECPP_INTERNAL_SQLITE_DEFAULT           ON)
+    set(SQLITECPP_BUILD_DYNAMIC_LIBRARY_DEFAULT     OFF)
+    set(SQLITECPP_DISABLE_MSVC_DLL_WARNINGS_DEFAULT ON)
+    set(SQLITE_ENABLE_COLUMN_METADATA_DEFAULT       ON)
 else (WIN32) # UNIX
     set(DEV_NULL                "/dev/null")
     # do not build the SQLite3 C library, but uses the Linux/Mac OS X sqlite3-dev package
-    set(SQLITECPP_INTERNAL_SQLITE_DEFAULT     OFF)
+    set(SQLITECPP_INTERNAL_SQLITE_DEFAULT           OFF)
+    set(SQLITECPP_BUILD_DYNAMIC_LIBRARY_DEFAULT     OFF)
+    set(SQLITECPP_DISABLE_MSVC_DLL_WARNINGS_DEFAULT OFF)
     if (APPLE)
         set(SQLITE_ENABLE_COLUMN_METADATA_DEFAULT OFF)
     else (APPLE)
@@ -26,17 +30,41 @@ else (WIN32) # UNIX
     endif (APPLE)
 endif (WIN32)
 
+# Options relative to SQLiteC++ build
+
+option(SQLITECPP_BUILD_DYNAMIC_LIBRARY "Build SQLiteC++ as a dynamic library." ${SQLITECPP_BUILD_DYNAMIC_LIBRARY_DEFAULT})
+if (SQLITECPP_BUILD_DYNAMIC_LIBRARY) 
+    # Define symbols to export DLL symbols with Visual Studio
+    add_definitions(-DSQLITECPP_DYNAMIC)
+	add_definitions(-DSQLITECPP_EXPORT)
+endif (SQLITECPP_BUILD_DYNAMIC_LIBRARY)
+
+option(SQLITECPP_DISABLE_MSVC_DLL_WARNINGS "Disable Visual Studio warning about std::classes DLL export." ${SQLITECPP_DISABLE_MSVC_DLL_WARNINGS_DEFAULT})
+if (SQLITECPP_DISABLE_MSVC_DLL_WARNINGS) 
+    # Disable Visual Studio warning about std::classes DLL export.
+    # These warnings can be ignored if the same runtime library is used for all libraries in your solution.
+    add_definitions(-DSQLITECPP_DISABLE_MSVC_DLL_WARNINGS)
+endif (SQLITECPP_DISABLE_MSVC_DLL_WARNINGS)
+
 # then Compiler/IDE differences:
 if (MSVC)
     set(CPPLINT_ARG_OUTPUT      "--output=vs7")
     set(CPPCHECK_ARG_TEMPLATE   "--template=vs")
     # disable Visual Studio warnings for fopen() used in the example
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-    # Flags for linking with multithread static C++ runtime
-    set(CMAKE_C_FLAGS_RELEASE   "${CMAKE_C_FLAGS_RELEASE} /MT")
-    set(CMAKE_C_FLAGS_DEBUG     "${CMAKE_C_FLAGS_DEBUG} /MTd")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
-    set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+    if (SQLITECPP_BUILD_DYNAMIC_LIBRARY) 
+        # Flags for linking with multithread dynamic C++ runtime
+        set(CMAKE_C_FLAGS_RELEASE   "${CMAKE_C_FLAGS_RELEASE} /MD")
+        set(CMAKE_C_FLAGS_DEBUG     "${CMAKE_C_FLAGS_DEBUG} /MDd")
+        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
+        set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
+    else (SQLITECPP_BUILD_DYNAMIC_LIBRARY)
+        # Flags for linking with multithread static C++ runtime
+        set(CMAKE_C_FLAGS_RELEASE   "${CMAKE_C_FLAGS_RELEASE} /MT")
+        set(CMAKE_C_FLAGS_DEBUG     "${CMAKE_C_FLAGS_DEBUG} /MTd")
+        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+        set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+    endif (SQLITECPP_BUILD_DYNAMIC_LIBRARY)
 else (MSVC)
     set(CPPLINT_ARG_OUTPUT      "--output=eclipse")
     set(CPPCHECK_ARG_TEMPLATE   "--template=gcc")
@@ -86,6 +114,7 @@ source_group(src FILES ${SQLITECPP_SRC})
 # list of header files of the library
 set(SQLITECPP_INC
  ${PROJECT_SOURCE_DIR}/include/SQLiteCpp/SQLiteCpp.h
+ ${PROJECT_SOURCE_DIR}/include/SQLiteCpp/SQLiteCppExport.h
  ${PROJECT_SOURCE_DIR}/include/SQLiteCpp/Assertion.h
  ${PROJECT_SOURCE_DIR}/include/SQLiteCpp/Column.h
  ${PROJECT_SOURCE_DIR}/include/SQLiteCpp/Database.h
@@ -134,8 +163,14 @@ source_group(scripts FILES ${SQLITECPP_SCRIPT})
 # All includes are relative to the "include" directory 
 include_directories("${PROJECT_SOURCE_DIR}/include")
 
-# add sources of the wrapper as a "SQLiteCpp" static library
-add_library(SQLiteCpp ${SQLITECPP_SRC} ${SQLITECPP_INC} ${SQLITECPP_DOC} ${SQLITECPP_SCRIPT})
+if (SQLITECPP_BUILD_DYNAMIC_LIBRARY) 
+    # add sources of the wrapper as a "SQLiteCpp" static library
+    add_library(SQLiteCpp SHARED ${SQLITECPP_SRC} ${SQLITECPP_INC} ${SQLITECPP_DOC} ${SQLITECPP_SCRIPT})
+    target_link_libraries(SQLiteCpp sqlite3)
+else (SQLITECPP_BUILD_DYNAMIC_LIBRARY)
+    # add sources of the wrapper as a "SQLiteCpp" dynamic library
+    add_library(SQLiteCpp STATIC ${SQLITECPP_SRC} ${SQLITECPP_INC} ${SQLITECPP_DOC} ${SQLITECPP_SCRIPT})
+endif (SQLITECPP_BUILD_DYNAMIC_LIBRARY)
 
 if (UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))
     set_target_properties(SQLiteCpp PROPERTIES COMPILE_FLAGS "-fPIC")

--- a/include/SQLiteCpp/Assertion.h
+++ b/include/SQLiteCpp/Assertion.h
@@ -12,6 +12,7 @@
 
 #include <cassert>
 
+#include <SQLiteCpp/SQLiteCppExport.h>
 
 /**
  * SQLITECPP_ASSERT SQLITECPP_ASSERT() is used in destructors, where exceptions shall not be thrown
@@ -26,8 +27,8 @@
 namespace SQLite
 {
     // declaration of the assert handler to define in user code
-    void assertion_failed(const char* apFile, const long apLine, const char* apFunc,
-                          const char* apExpr, const char* apMsg);
+    SQLITECPP_DLL void assertion_failed(const char* apFile, const long apLine, const char* apFunc,
+                                        const char* apExpr, const char* apMsg);
 
 #ifdef _MSC_VER
     #define __func__ __FUNCTION__

--- a/include/SQLiteCpp/Column.h
+++ b/include/SQLiteCpp/Column.h
@@ -231,7 +231,7 @@ private:
  *
  * @return  Reference to the stream used
  */
-std::ostream& operator<<(std::ostream& aStream, const Column& aColumn);
+SQLITECPP_DLL std::ostream& operator<<(std::ostream& aStream, const Column& aColumn);
 
 
 }  // namespace SQLite

--- a/include/SQLiteCpp/Column.h
+++ b/include/SQLiteCpp/Column.h
@@ -12,6 +12,7 @@
 
 #include <sqlite3.h>
 
+#include <SQLiteCpp/SQLiteCppExport.h>
 #include <SQLiteCpp/Statement.h>
 #include <SQLiteCpp/Exception.h>
 
@@ -38,7 +39,7 @@ namespace SQLite
  *    because of the way it shares the underling SQLite precompiled statement
  *    in a custom shared pointer (See the inner class "Statement::Ptr").
  */
-class Column
+class SQLITECPP_DLL Column
 {
 public:
     // Make clang happy by explicitly implementing the copy-constructor:

--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -12,6 +12,7 @@
 
 #include <sqlite3.h>
 
+#include <SQLiteCpp/SQLiteCppExport.h>
 #include <SQLiteCpp/Column.h>
 
 #include <string>
@@ -38,7 +39,7 @@ namespace SQLite
  *    because of the way it shares the underling SQLite precompiled statement
  *    in a custom shared pointer (See the inner class "Statement::Ptr").
  */
-class Database
+class SQLITECPP_DLL Database
 {
     friend class Statement; // Give Statement constructor access to the mpSQLite Connection Handle
 

--- a/include/SQLiteCpp/Exception.h
+++ b/include/SQLiteCpp/Exception.h
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <string>
 
+#include <SQLiteCpp/SQLiteCppExport.h>
 
 namespace SQLite
 {
@@ -21,7 +22,7 @@ namespace SQLite
 /**
  * @brief Encapsulation of the error message from SQLite3, based on std::runtime_error.
  */
-class Exception : public std::runtime_error
+class SQLITECPP_DLL Exception : public std::runtime_error
 {
 public:
     /**

--- a/include/SQLiteCpp/SQLiteCpp.h
+++ b/include/SQLiteCpp/SQLiteCpp.h
@@ -16,8 +16,8 @@
  */
 #pragma once
 
-
 // Include useful headers of SQLiteC++
+#include <SQLiteCpp/SQLiteCppExport.h>
 #include <SQLiteCpp/Assertion.h>
 #include <SQLiteCpp/Exception.h>
 #include <SQLiteCpp/Database.h>

--- a/include/SQLiteCpp/SQLiteCppExport.h
+++ b/include/SQLiteCpp/SQLiteCppExport.h
@@ -1,0 +1,30 @@
+/**
+ * @file    SQLiteCpp.h
+ * @ingroup SQLiteCpp
+ * @brief   SQLiteC++ is a smart and simple C++ SQLite3 wrapper. This file is only "easy include" for other files.
+ *
+ * Copyright (c) 2012-2015 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ *
+ * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
+ * or copy at http://opensource.org/licenses/MIT)
+ */
+#pragma once
+//
+#ifdef SQLITECPP_DYNAMIC
+#	if defined(WIN32)
+#		ifdef SQLITECPP_EXPORT
+#			define SQLITECPP_DLL __declspec(dllexport)
+#		else
+#			define SQLITECPP_DLL __declspec(dllimport)
+#		endif
+#	else
+#		define SQLITECPP_DLL	
+#	endif
+#else
+#	define SQLITECPP_DLL	
+#endif
+// Disable VisualStudio warnings about DLL exports
+#if defined(_MSC_VER) && defined(SQLITECPP_DYNAMIC) && defined(SQLITECPP_DISABLE_MSVC_WARNINGS)
+    #pragma warning( disable : 4251 )
+    #pragma warning( disable : 4275 )
+#endif

--- a/include/SQLiteCpp/SQLiteCppExport.h
+++ b/include/SQLiteCpp/SQLiteCppExport.h
@@ -24,7 +24,7 @@
 #	define SQLITECPP_DLL	
 #endif
 // Disable VisualStudio warnings about DLL exports
-#if defined(_MSC_VER) && defined(SQLITECPP_DYNAMIC) && defined(SQLITECPP_DISABLE_MSVC_WARNINGS)
+#if defined(_MSC_VER) && defined(SQLITECPP_DYNAMIC) && defined(SQLITECPP_DISABLE_MSVC_DLL_WARNINGS)
     #pragma warning( disable : 4251 )
     #pragma warning( disable : 4275 )
 #endif

--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <map>
 
+#include <SQLiteCpp/SQLiteCppExport.h>
 #include <SQLiteCpp/Exception.h>
 
 
@@ -42,10 +43,10 @@ class Column;
  *    because of the way it shares the underling SQLite precompiled statement
  *    in a custom shared pointer (See the inner class "Statement::Ptr").
  */
-class Statement
+class SQLITECPP_DLL Statement
 {
 public:
-    class Ptr;
+    class SQLITECPP_DLL Ptr;
 
     /**
      * @brief Compile and register the SQL query for the provided SQLite Database Connection

--- a/include/SQLiteCpp/Transaction.h
+++ b/include/SQLiteCpp/Transaction.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 
+#include <SQLiteCpp/SQLiteCppExport.h>
 #include <SQLiteCpp/Exception.h>
 
 
@@ -40,7 +41,7 @@ class Database;
  *    because of the way it shares the underling SQLite precompiled statement
  *    in a custom shared pointer (See the inner class "Statement::Ptr").
  */
-class Transaction
+class SQLITECPP_DLL Transaction
 {
 public:
     /**


### PR DESCRIPTION
I've made following changes :
- added SQLiteCppExport.h header which contains DLL import / export directive for Windows and Linux
- added the SQLITECPP_DLL macro on all symbols to be exported
- modified the CMakeList file to add new options

There is 3 new preprocessor "DEFINE" symbols :
- SQLITECPP_DYNAMIC : 
  => if defined, this mean SQLiteCpp is being build/used as a dynamic library
- SQLITECPP_EXPORT: 
  => if defined, this mean SQLiteCpp is being BUILD as a dynamic library, and it will EXPORT its symbols
  => if not defined, this mean SQLiteCpp is being USED as a dynamic library, and it will IMPORT its symbols
- SQLITECPP_DISABLE_MSVC_DLL_WARNINGS :
  => if defined, this mean Visual Studio should ignore the DLL export warnings about STL classes. You can ignore that when you build all your solution with the same runtime library. (if you don't do that, you will have very bad time anyway)
# 

I'm not an expert in CMake files, and there is still something to fix in the actual file : the "SQLITECPP_EXPORT" is defined when a dynamic library build is asked, but even to build the example.

The example should not define this symbol because it need to IMPORT the code, not export it.

My guess is a subdirectory with a specific configuration is needed for every target : SQLite3, SQLiteCpp and Example
