### PR TITLE
Fix implicit conversion to std::string of Column class for Visual C++ 2015

### DIFF
--- a/include/SQLiteCpp/Column.h
+++ b/include/SQLiteCpp/Column.h
@@ -187,10 +187,10 @@ public:
         return getBlob();
     }
 
-#ifdef __GNUC__
+#if !(defined(_MSC_VER) && _MSC_VER < 1900)
     // NOTE : the following is required by GCC and Clang to cast a Column result in a std::string
     // (error: conversion from ‘SQLite::Column’ to non-scalar type ‘std::string {aka std::basic_string<char>}’)
-    // but is not working under Microsoft Visual Studio 2010 and 2012
+    // but is not working under Microsoft Visual Studio 2010, 2012 and 2013
     // (error C2440: 'initializing' : cannot convert from 'SQLite::Column' to 'std::basic_string<_Elem,_Traits,_Ax>'
     //  [...] constructor overload resolution was ambiguous)
     /// Inline cast operator to std::string


### PR DESCRIPTION
I have changed `#if` condition masking `Column::operator std::string`, because a problem that implicit conversion to `std::string` does not work if there are both `operator std::string` and `operator const char *` is fixed from Visual C++ 2015.

The condition became more generic to support "standard" compilers not defining `__GNUC__`.