### PR TITLE
Variadic bind convenience function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ set(SQLITECPP_TESTS
  tests/Database_test.cpp
  tests/Statement_test.cpp
  tests/Backup_test.cpp
+ tests/VariadicBind_test.cpp
 )
 source_group(tests FILES ${SQLITECPP_TESTS})
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -1935,7 +1935,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = __cplusplus=201402L
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/examples/example1/main.cpp
+++ b/examples/example1/main.cpp
@@ -454,7 +454,6 @@ int main ()
 
 	//example with variadic bind (requires c++14)
 	try {
-		std::cout<<"cplusplus version is "<<__cplusplus<<'\n';
 		demonstrateVariadicBind();
 	} catch (std::exception& e) {
 		std::cout << "SQLite exception: " << e.what() << std::endl;

--- a/examples/example1/main.cpp
+++ b/examples/example1/main.cpp
@@ -453,12 +453,14 @@ int main ()
     remove("out.png");
 
 	//example with variadic bind (requires c++14)
+#if ( __cplusplus>= 201402L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) )
 	try {
 		demonstrateVariadicBind();
 	} catch (std::exception& e) {
 		std::cout << "SQLite exception: " << e.what() << std::endl;
 		return EXIT_FAILURE; // unexpected error : exit the example program
 	}
+#endif
 
     std::cout << "everything ok, quitting\n";
 

--- a/include/SQLiteCpp/VariadicBind.h
+++ b/include/SQLiteCpp/VariadicBind.h
@@ -1,0 +1,74 @@
+/**
+ * @file    VariadicBind.h
+ * @ingroup SQLiteCpp
+ * @brief   Convenience function for Statement::bind(...)
+ *
+ * Copyright (c) 2016 Paul Dreik (github@pauldreik.se)
+ *
+ * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
+ * or copy at http://opensource.org/licenses/MIT)
+ */
+#pragma once
+
+#include <SQLiteCpp/Statement.h>
+
+namespace SQLite
+{
+
+
+//this requires c++14. seems like visual studio 2015 should work (yet untested).
+#if ( __cplusplus>= 201402L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) )
+/// @cond
+#include <utility>
+#include <initializer_list>
+
+/// implementation detail for variadic bind.
+namespace detail {
+template<class F,class ...Args, std::size_t ... I>
+inline void invoke_with_index(F&& f, std::integer_sequence<std::size_t, I...>,
+    const Args& ...args) {
+  std::initializer_list<int> { (f(I+1,args),0)... };
+}
+
+/// implementation detail for variadic bind.
+template<class F,class ...Args>
+inline void invoke_with_index(F&&f, const Args& ... args) {
+  invoke_with_index(std::forward<F>(f),std::index_sequence_for<Args...>(), args...);
+}
+
+} //namespace detail
+/// @endcond
+
+/**
+ * \brief Convenience function for calling Statement::bind(...) once for each argument given.
+ *
+ * This takes care of incrementing the index between each calls to bind.
+ *
+ * This feature requires a c++14 capable compiler.
+ *
+ * \code{.cpp}
+ * SQLite::Statement stm("SELECT * FROM MyTable WHERE colA>? && colB=? && colC<?");
+ * bind(stm,a,b,c);
+ * //...is equivalent to
+ * stm.bind(1,a);
+ * stm.bind(2,b);
+ * stm.bind(3,c);
+ * \endcode
+ * @param s statement
+ * @param args one or more args to bind.
+ */
+template<class ...Args>
+void bind(SQLite::Statement& s,const Args& ... args) {
+
+  static_assert(sizeof...(args)>0,"please invoke bind with one or more args");
+
+  auto f=[&s](std::size_t index, const auto& value) {
+    s.bind(index,value);
+  };
+  detail::invoke_with_index(f, args...);
+}
+#else
+//not supported in older c++. provide a fallback?
+#endif // c++14
+
+}  // namespace SQLite

--- a/include/SQLiteCpp/VariadicBind.h
+++ b/include/SQLiteCpp/VariadicBind.h
@@ -12,8 +12,7 @@
 
 #include <SQLiteCpp/Statement.h>
 
-namespace SQLite
-{
+
 
 
 //this requires c++14. seems like visual studio 2015 should work (yet untested).
@@ -21,6 +20,9 @@ namespace SQLite
 /// @cond
 #include <utility>
 #include <initializer_list>
+
+namespace SQLite
+{
 
 /// implementation detail for variadic bind.
 namespace detail {
@@ -67,8 +69,10 @@ void bind(SQLite::Statement& s,const Args& ... args) {
   };
   detail::invoke_with_index(f, args...);
 }
+
+}  // namespace SQLite
+
 #else
 //not supported in older c++. provide a fallback?
 #endif // c++14
 
-}  // namespace SQLite

--- a/tests/VariadicBind_test.cpp
+++ b/tests/VariadicBind_test.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file    VariadicBind_test.cpp
+ * @ingroup tests
+ * @brief   Test of variadic bind
+ *
+ * Copyright (c) 2016 Paul Dreik (github@pauldreik.se)
+ *
+ * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
+ * or copy at http://opensource.org/licenses/MIT)
+ */
+
+#include <SQLiteCpp/Database.h>
+#include <SQLiteCpp/Statement.h>
+#include <SQLiteCpp/VariadicBind.h>
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+
+//this requires c++14. seems like visual studio 2015 should work (yet untested).
+#if ( __cplusplus>= 201402L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) )
+
+TEST(VariadicBind, invalid) {
+	// Create a new database
+#if 0
+	SQLite::Database db("variadic_bind_test.db3", SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
+#else
+	SQLite::Database db(":memory:", SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
+#endif
+
+	EXPECT_EQ(0, db.exec("DROP TABLE IF EXISTS test"));
+	EXPECT_EQ(0,
+			db.exec(
+					"CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT DEFAULT 'default') "));
+	EXPECT_TRUE(db.tableExists("test"));
+
+	{
+		SQLite::Statement query(db, "INSERT INTO test VALUES (?, ?)");
+
+		//zero arguments - should give compile time error through a static assert
+		//SQLite::bind(query);
+
+		//bind one argument less than expected - should be fine.
+		//the unspecified argument should be set to null, not the default.
+		SQLite::bind(query, 1);
+		EXPECT_EQ(1, query.exec());
+		query.reset();
+
+		//bind all arguments - should work just fine
+		SQLite::bind(query, 2, "two");
+		EXPECT_EQ(1, query.exec());
+		query.reset();
+
+		//bind too many arguments - should throw.
+		EXPECT_THROW(SQLite::bind(query, 3, "three", 0), SQLite::Exception);
+		EXPECT_EQ(1, query.exec());
+	}
+
+	//make sure the content is as expected
+	{
+		using namespace std::string_literals;
+
+		SQLite::Statement query(db, "SELECT id, value FROM test ORDER BY id"s);
+		std::vector<std::pair<int, std::string> > results;
+		while (query.executeStep()) {
+			const int id = query.getColumn(0);
+			std::string value = query.getColumn(1);
+			results.emplace_back( id, std::move(value) );
+		}
+		EXPECT_EQ(std::size_t(3), results.size());
+
+		EXPECT_EQ(std::make_pair(1,""s), results.at(0));
+		EXPECT_EQ(std::make_pair(2,"two"s), results.at(1));
+		EXPECT_EQ(std::make_pair(3,"three"s), results.at(2));
+	}
+}
+#endif // c++14


### PR DESCRIPTION
This gives the possibility to let the compiler generate the index argument in `Statement::bind()` automatically at compile time, instead of manually invoking bind.
Instead of
`SQLite::Statement stmt("SELECT * FROM MyTable WHERE colA>? && colB=? && colC<?");
stmt.bind(1,a);
 stmt.bind(2,b);
 stmt.bind(3,c);
`
one can write
`SQLite::bind(stmt,a,b,c);`

Note that this is implemented as a free function. It could be provided as a member function of `SQLite::Statement` instead, under a different name than bind in order not to clash with the existing `SQLite::Statement::bind()` overloads.

This requires c++14. Tested on gcc 5.3.1 on GNU/Linux.