### PR TITLE
Automatically propagate public headers to other projects with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ include_directories("${PROJECT_SOURCE_DIR}/include")
 
 # add sources of the wrapper as a "SQLiteCpp" static library
 add_library(SQLiteCpp ${SQLITECPP_SRC} ${SQLITECPP_INC} ${SQLITECPP_DOC} ${SQLITECPP_SCRIPT})
+target_include_directories(SQLiteCpp PUBLIC "${PROJECT_SOURCE_DIR}/include")
 
 if (UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))
     set_target_properties(SQLiteCpp PROPERTIES COMPILE_FLAGS "-fPIC")
@@ -170,6 +171,7 @@ if (SQLITECPP_INTERNAL_SQLITE)
     # build the SQLite3 C library (for ease of use/compatibility) versus Linux sqlite3-dev package
     add_subdirectory(sqlite3)
     include_directories("${PROJECT_SOURCE_DIR}/sqlite3")
+    target_include_directories(sqlite3 PUBLIC "${PROJECT_SOURCE_DIR}/sqlite3")
 endif (SQLITECPP_INTERNAL_SQLITE)
 
 


### PR DESCRIPTION
I'm adding SQLiteCpp to my project with CMake, using `add_subdirectory`.

The problem I found is that I need to manually add the path to the public header files (SQLiteCpp/include/ and SQLiteCpp/sqlite3), since they are not propagated automatically.

This PR add the `target_include_directories` so that the projects that include SQLiteCpp don't need to include the path to the public header files manually.