### PR TITLE
Fixed link errors calling Exception::getErrorCode()

### DIFF
--- a/include/SQLiteCpp/Exception.h
+++ b/include/SQLiteCpp/Exception.h
@@ -76,10 +76,14 @@ public:
     Exception(sqlite3* apSQLite, int ret);
 
     /// Return the result code (if any, otherwise -1).
-    int getErrorCode() const noexcept; // nothrow
+    int getErrorCode() const noexcept { // nothrow
+        return mErrcode;
+    }
 
     /// Return the extended numeric result code (if any, otherwise -1).
-    int getExtendedErrorCode() const noexcept; // nothrow
+    int getExtendedErrorCode() const noexcept { // nothrow
+        return mExtendedErrcode;
+    }
 
     /// Return a string, solely based on the error code
     const char* getErrorStr() const noexcept; // nothrow

--- a/src/Exception.cpp
+++ b/src/Exception.cpp
@@ -44,20 +44,8 @@ Exception::Exception(sqlite3* apSQLite, int ret) :
 {
 }
 
-// Return the result code (if any, otherwise -1).
-inline int Exception::getErrorCode() const noexcept // nothrow
-{
-    return mErrcode;
-}
-
-// Return the extended numeric result code (if any, otherwise -1).
-inline int Exception::getExtendedErrorCode() const noexcept // nothrow
-{
-    return mExtendedErrcode;
-}
-
 // Return a string, solely based on the error code
-inline const char* Exception::getErrorStr() const noexcept // nothrow
+const char* Exception::getErrorStr() const noexcept // nothrow
 {
     return sqlite3_errstr(mErrcode);
 }


### PR DESCRIPTION
getErrorCode() and getExtendedErrorCode()'s implementations were
accidentally declared as inline in the .cpp file. This causes the
compiler to not generate any code for them, resulting in link errors
when a client calls them. (Observed compiling with Clang.)

Fixed by moving the implementations into the header, where they need to
be if they're inline.