### PR TITLE
Redundant const specifier removed

### DIFF
--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -45,7 +45,7 @@ extern const int    VERSION_NUMBER; ///< SQLITE_VERSION_NUMBER from the sqlite3.
 /// Return SQLite version string using runtime call to the compiled library
 const char* getLibVersion() noexcept; // nothrow
 /// Return SQLite version number using runtime call to the compiled library
-const int   getLibVersionNumber() noexcept; // nothrow
+int   getLibVersionNumber() noexcept; // nothrow
 
 
 /**

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -41,7 +41,7 @@ const char* getLibVersion() noexcept // nothrow
 }
 
 // Return SQLite version number using runtime call to the compiled library
-const int getLibVersionNumber() noexcept // nothrow
+int getLibVersionNumber() noexcept // nothrow
 {
     return sqlite3_libversion_number();
 }


### PR DESCRIPTION
Fixes clang warning on Database.h:48: "'const' type qualifier on return type has no effect" and Database.cpp:44: "'const' type qualifier on return type has no effect"