### PR TITLE
Added convenience functions for constructing objects from a row

### DIFF
--- a/include/SQLiteCpp/Column.h
+++ b/include/SQLiteCpp/Column.h
@@ -260,5 +260,22 @@ private:
  */
 std::ostream& operator<<(std::ostream& aStream, const Column& aColumn);
 
+#if __cplusplus >= 201402L || (defined(_MSC_VER) && _MSC_VER >= 1900)
+    // Create an instance of T from the first N columns, see declaration in Statement.h for full details
+    template<typename T, int N>
+    T Statement::getColumns()
+    {
+        checkRow();
+        checkIndex(N - 1);
+        return getColumns<T>(std::make_integer_sequence<int, N>{});
+    }
+
+    // Helper function called by getColums<typename T, int N>
+    template<typename T, const int... Is>
+    T Statement::getColumns(const std::integer_sequence<int, Is...>)
+    {
+        return T(Column(mStmtPtr, Is)...);
+    }
+#endif
 
 }  // namespace SQLite

--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -427,6 +427,40 @@ public:
      */
     Column  getColumn(const char* apName);
 
+#if __cplusplus >= 201402L || (defined(_MSC_VER) && _MSC_VER >= 1900)
+     /**
+     * @brief Return an instance of T constructed from copies of the first N columns
+     *
+     *  Can be used to access the data of the current row of result when applicable,
+     * while the executeStep() method returns true.
+     *
+     *  Throw an exception if there is no row to return a Column from:
+     * - if provided column count is out of bound
+     * - before any executeStep() call
+     * - after the last executeStep() returned false
+     * - after a reset() call
+     *
+     *  Throw an exception if the specified column count is out of the [0, getColumnCount()) range.
+     *
+     * @tparam  T   Object type to construct
+     * @tparam  N   Number of columns
+     *
+     * @note Requires std=C++14
+     */
+    template<typename T, int N>
+    T       getColumns();
+
+private:
+    /**
+    * @brief Helper function used by getColumns<typename T, int N> to expand an integer_sequence used to generate
+    *        the required Column objects
+    */
+    template<typename T, const int... Is>
+    T       getColumns(const std::integer_sequence<int, Is...>);
+
+public:
+#endif
+
     /**
      * @brief Test if the column value is NULL
      *


### PR DESCRIPTION
Added a template function that allows you to retrieve all columns (or first N columns) of a row as an object. Extremely convenient when working with a table that has a large number of columns. Instead of having to do:
int i0 = query.getColumn(0);
int i1 = query.getColumn(1);
...
int i39 = query.getColumn(39);

then passing all those temporary variables into a constructor, you can do:

auto i = query.getColumns<MyClass, 40>();

where MyClass has a constructor that takes 40 arguments that are convertible from a Column object.

