### PR TITLE
added private assigment operator to Exception class to avoid MSVC warning

### DIFF
--- a/include/SQLiteCpp/Exception.h
+++ b/include/SQLiteCpp/Exception.h
@@ -91,6 +91,9 @@ public:
     const char* getErrorStr() const noexcept; // nothrow
 
 private:
+    // due to constant members the auto-assignment operator can not be generated
+    Exception& operator=(const Exception&);
+
     const int mErrcode;         ///< Error code value
     const int mExtendedErrcode; ///< Detailed error code if any
 };


### PR DESCRIPTION
added private assigment operator to Exception class to avoid MSVC warning: C4512: 'SQLite::Exception' : assignment operator could not be generated ...' --> only created at warning level 4 !