### PR TITLE
Ensure that operator<< correctly prints strings with embedded '\0'

### DIFF
--- a/src/Column.cpp
+++ b/src/Column.cpp
@@ -116,7 +116,7 @@ int Column::getBytes() const noexcept // nothrow
 // Standard std::ostream inserter
 std::ostream& operator<<(std::ostream& aStream, const Column& aColumn)
 {
-    aStream << aColumn.getText();
+    aStream.write(aColumn.getText(), aColumn.getBytes());
     return aStream;
 }
 

--- a/tests/Column_test.cpp
+++ b/tests/Column_test.cpp
@@ -199,3 +199,27 @@ TEST(Column, getName) {
     EXPECT_EQ("msg",    oname1);
 #endif
 }
+
+TEST(Column, stream) {
+    // Create a new database
+    SQLite::Database db(":memory:", SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
+    EXPECT_EQ(0, db.exec("CREATE TABLE test (msg TEXT)"));
+    SQLite::Statement insert(db, "INSERT INTO test VALUES (?)");
+
+    // content to test
+    const char str_[] = "stringwith\0embedded";
+    std::string str(str_, sizeof(str_)-1);
+
+    insert.bind(1, str);
+    // Execute the one-step query to insert the row
+    EXPECT_EQ(1, insert.exec());
+    EXPECT_EQ(1, db.getTotalChanges());
+
+    SQLite::Statement query(db, "SELECT * FROM test");
+    query.executeStep();
+    std::stringstream ss;
+    auto col = query.getColumn(0);
+    ss << query.getColumn(0);
+    std::string content = ss.str();
+    EXPECT_EQ(content, str);
+}

--- a/tests/Column_test.cpp
+++ b/tests/Column_test.cpp
@@ -218,7 +218,6 @@ TEST(Column, stream) {
     SQLite::Statement query(db, "SELECT * FROM test");
     query.executeStep();
     std::stringstream ss;
-    auto col = query.getColumn(0);
     ss << query.getColumn(0);
     std::string content = ss.str();
     EXPECT_EQ(content, str);


### PR DESCRIPTION
Hello,

std::ostream& operator<<(std::ostream& aStream, const Column& aColumn) does not handle correctly content with an embedded '\0'.
I've also added a test case with a std::string.

Best regards
Federico