### PR TITLE
Remove noexcept

### DIFF
--- a/include/SQLiteCpp/Column.h
+++ b/include/SQLiteCpp/Column.h
@@ -111,7 +111,7 @@ public:
      *
      * Note this correctly handles strings that contain null bytes.
      */
-    std::string getString() const noexcept; // nothrow
+    std::string getString() const;
 
     /**
      * @brief Return the type of the value of the column

--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -142,7 +142,7 @@ public:
      *
      * @throw SQLite::Exception in case of error
      */
-    void setBusyTimeout(const int aBusyTimeoutMs) noexcept; // nothrow
+    void setBusyTimeout(const int aBusyTimeoutMs);
 
     /**
      * @brief Shortcut to execute one or multiple statements without results.

--- a/src/Column.cpp
+++ b/src/Column.cpp
@@ -90,7 +90,7 @@ const void* Column::getBlob() const noexcept // nothrow
 }
 
 // Return a std::string to a TEXT or BLOB column
-std::string Column::getString() const noexcept // nothrow
+std::string Column::getString() const
 {
     // Note: using sqlite3_column_blob and not sqlite3_column_text
     // - no need for sqlite3_column_text to add a \0 on the end, as we're getting the bytes length directly

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -117,7 +117,7 @@ Database::~Database() noexcept // nothrow
  *
  * @throw SQLite::Exception in case of error
  */
-void Database::setBusyTimeout(const int aBusyTimeoutMs) noexcept // nothrow
+void Database::setBusyTimeout(const int aBusyTimeoutMs)
 {
     const int ret = sqlite3_busy_timeout(mpSQLite, aBusyTimeoutMs);
     check(ret);


### PR DESCRIPTION
Hi,

there are a couple of method marked as noexcept, but in reality they may throw an exception.

The first method is Column::getString, since std::string needs to allocate memory, the constructor may fail and throw an exception

The second method is Database::setBusyTimeout, internally if the operation fails an exception is thrown.

I was going to remove the noexcept specifier from the destructors, since they are all noexcept if not stated otherwise, but maybe you preferred to state it explicitely, and since it does not make any difference from the language perspective, I leaved them.