### PR TITLE
Enhance sqlite exception

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ set(SQLITECPP_TESTS
  tests/Backup_test.cpp
  tests/Transaction_test.cpp
  tests/VariadicBind_test.cpp
+ tests/Exception_test.cpp
 )
 source_group(tests FILES ${SQLITECPP_TESTS})
 

--- a/include/SQLiteCpp/Exception.h
+++ b/include/SQLiteCpp/Exception.h
@@ -91,8 +91,8 @@ public:
     const char* getErrorStr() const noexcept; // nothrow
 
 private:
-    const int mErrcode;         ///< Error code value
-    const int mExtendedErrcode; ///< Detailed error code if any
+    int mErrcode;         ///< Error code value
+    int mExtendedErrcode; ///< Detailed error code if any
 };
 
 

--- a/include/SQLiteCpp/Exception.h
+++ b/include/SQLiteCpp/Exception.h
@@ -50,6 +50,7 @@ public:
      *
      * @param[in] aErrorMessage The string message describing the SQLite error
      */
+    explicit Exception(const char* aErrorMessage);
     explicit Exception(const std::string& aErrorMessage);
 
     /**
@@ -58,6 +59,7 @@ public:
      * @param[in] aErrorMessage The string message describing the SQLite error
      * @param[in] ret           Return value from function call that failed.
      */
+    Exception(const char* aErrorMessage, int ret);
     Exception(const std::string& aErrorMessage, int ret);
 
    /**

--- a/src/Exception.cpp
+++ b/src/Exception.cpp
@@ -16,9 +16,22 @@
 namespace SQLite
 {
 
+Exception::Exception(const char* aErrorMessage) :
+    std::runtime_error(aErrorMessage),
+    mErrcode(-1), // 0 would be SQLITE_OK, which doesn't make sense
+    mExtendedErrcode(-1)
+{
+}
 Exception::Exception(const std::string& aErrorMessage) :
     std::runtime_error(aErrorMessage),
     mErrcode(-1), // 0 would be SQLITE_OK, which doesn't make sense
+    mExtendedErrcode(-1)
+{
+}
+
+Exception::Exception(const char* aErrorMessage, int ret) :
+    std::runtime_error(aErrorMessage),
+    mErrcode(ret),
     mExtendedErrcode(-1)
 {
 }

--- a/tests/Exception_test.cpp
+++ b/tests/Exception_test.cpp
@@ -53,10 +53,14 @@ TEST(Exception, constructor) {
         const SQLite::Exception ex1(msg1);
         const SQLite::Exception ex2(msg2);
         EXPECT_STREQ(ex1.what(), ex2.what());
+        EXPECT_EQ(ex1.getErrorCode(), ex2.getErrorCode());
+        EXPECT_EQ(ex1.getExtendedErrorCode(), ex2.getExtendedErrorCode());
     }
     {
         const SQLite::Exception ex1(msg1, 1);
         const SQLite::Exception ex2(msg2, 1);
         EXPECT_STREQ(ex1.what(), ex2.what());
+        EXPECT_EQ(ex1.getErrorCode(), ex2.getErrorCode());
+        EXPECT_EQ(ex1.getExtendedErrorCode(), ex2.getExtendedErrorCode());
     }
 }

--- a/tests/Exception_test.cpp
+++ b/tests/Exception_test.cpp
@@ -1,0 +1,44 @@
+/**
+ * @file    Transaction_test.cpp
+ * @ingroup tests
+ * @brief   Test of a SQLite Transaction.
+ *
+ * Copyright (c) 2012-2016 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ *
+ * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
+ * or copy at http://opensource.org/licenses/MIT)
+ */
+
+#include <SQLiteCpp/Exception.h>
+
+#include <gtest/gtest.h>
+
+TEST(Exception, copy) {
+    const SQLite::Exception ex1("some error", 2);
+    const SQLite::Exception ex2 = ex1;
+    EXPECT_STREQ(ex1.what(), ex2.what());
+    EXPECT_EQ(ex1.getErrorCode(), ex2.getErrorCode());
+    EXPECT_EQ(ex1.getExtendedErrorCode(), ex2.getExtendedErrorCode());
+}
+
+// see http://eel.is/c++draft/exception#2 or http://www.cplusplus.com/reference/exception/exception/operator=/
+// an assignment operator is expected to be avaiable
+TEST(Exception, assignment) {
+    const SQLite::Exception ex1("some error", 2);
+    SQLite::Exception ex2("some error2", 3);
+
+    ex2 = ex1;
+
+    EXPECT_STREQ(ex1.what(), ex2.what());
+    EXPECT_EQ(ex1.getErrorCode(), ex2.getErrorCode());
+    EXPECT_EQ(ex1.getExtendedErrorCode(), ex2.getExtendedErrorCode());
+}
+
+TEST(Exception, throw_catch) {
+    const char message[] = "some error";
+    try {
+        throw SQLite::Exception(message);
+    } catch (const std::runtime_error& ex) {
+        EXPECT_STREQ(ex.what(), message);
+    }
+}

--- a/tests/Exception_test.cpp
+++ b/tests/Exception_test.cpp
@@ -13,6 +13,8 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+
 TEST(Exception, copy) {
     const SQLite::Exception ex1("some error", 2);
     const SQLite::Exception ex2 = ex1;
@@ -40,5 +42,21 @@ TEST(Exception, throw_catch) {
         throw SQLite::Exception(message);
     } catch (const std::runtime_error& ex) {
         EXPECT_STREQ(ex.what(), message);
+    }
+}
+
+
+TEST(Exception, constructor) {
+    const char msg1[] = "error msg";
+    std::string msg2 = msg1;
+    {
+        const SQLite::Exception ex1(msg1);
+        const SQLite::Exception ex2(msg2);
+        EXPECT_STREQ(ex1.what(), ex2.what());
+    }
+    {
+        const SQLite::Exception ex1(msg1, 1);
+        const SQLite::Exception ex2(msg2, 1);
+        EXPECT_STREQ(ex1.what(), ex2.what());
     }
 }


### PR DESCRIPTION
Hi,

subclasses of std::exception should have an assignment operator.

I've added test cases to ensure that such operator behaves correctly.

I've also added two constructor that takes const char* instead of const std::string& in order to avoid a possible allocation (in c++11) when creating the exception object.