### PR TITLE
Remove unnecessary noexcept identifier from destructors

### DIFF
--- a/include/SQLiteCpp/Backup.h
+++ b/include/SQLiteCpp/Backup.h
@@ -100,7 +100,7 @@ public:
            Database& aSrcDatabase);
 
     /// Release the SQLite Backup resource.
-    virtual ~Backup() noexcept;
+    virtual ~Backup();
 
     /**
      * @brief Execute a step of backup with a given number of source pages to be copied

--- a/include/SQLiteCpp/Column.h
+++ b/include/SQLiteCpp/Column.h
@@ -54,7 +54,7 @@ public:
      */
     Column(Statement::Ptr& aStmtPtr, int aIndex)    noexcept; // nothrow
     /// Simple destructor
-    virtual ~Column()                               noexcept; // nothrow
+    virtual ~Column();
 
     // default copy constructor and assignment operator are perfectly suited :
     // they copy the Statement::Ptr which in turn increments the reference counter.

--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -127,7 +127,7 @@ public:
      *
      * @warning assert in case of error
      */
-    virtual ~Database() noexcept; // nothrow
+    virtual ~Database();
 
     /**
      * @brief Set a busy handler that sleeps for a specified amount of time when a table is locked.

--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -73,7 +73,7 @@ public:
     Statement(Database& aDatabase, const std::string& aQuery);
 
     /// Finalize and unregister the SQL query from the SQLite Database Connection.
-    virtual ~Statement() noexcept; // nothrow
+    virtual ~Statement();
 
     /// Reset the statement to make it ready for a new execution.
     void reset();
@@ -564,7 +564,7 @@ private:
         // Copy constructor increments the ref counter
         Ptr(const Ptr& aPtr);
         // Decrement the ref counter and finalize the sqlite3_stmt when it reaches 0
-        ~Ptr() noexcept; // nothrow (no virtual destructor needed here)
+        ~Ptr();
 
         /// Inline cast operator returning the pointer to SQLite Database Connection Handle
         inline operator sqlite3*() const

--- a/include/SQLiteCpp/Transaction.h
+++ b/include/SQLiteCpp/Transaction.h
@@ -55,7 +55,7 @@ public:
     /**
      * @brief Safely rollback the transaction if it has not been committed.
      */
-    virtual ~Transaction() noexcept; // nothrow
+    virtual ~Transaction();
 
     /**
      * @brief Commit the transaction.

--- a/src/Backup.cpp
+++ b/src/Backup.cpp
@@ -70,7 +70,7 @@ Backup::Backup(Database &aDestDatabase, Database &aSrcDatabase) :
 }
 
 // Release resource for SQLite database backup
-Backup::~Backup() noexcept
+Backup::~Backup()
 {
     if (NULL != mpSQLiteBackup)
     {

--- a/src/Column.cpp
+++ b/src/Column.cpp
@@ -33,7 +33,7 @@ Column::Column(Statement::Ptr& aStmtPtr, int aIndex) noexcept : // nothrow
 }
 
 // Finalize and unregister the SQL query from the SQLite Database Connection.
-Column::~Column() noexcept // nothrow
+Column::~Column()
 {
     // the finalization will be done by the destructor of the last shared pointer
 }

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -92,7 +92,7 @@ Database::Database(const std::string& aFilename,
 }
 
 // Close the SQLite database connection.
-Database::~Database() noexcept // nothrow
+Database::~Database()
 {
     const int ret = sqlite3_close(mpSQLite);
 

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -44,7 +44,7 @@ Statement::Statement(Database &aDatabase, const std::string& aQuery) :
 
 
 // Finalize and unregister the SQL query from the SQLite Database Connection.
-Statement::~Statement() noexcept // nothrow
+Statement::~Statement()
 {
     // the finalization will be done by the destructor of the last shared pointer
 }
@@ -437,7 +437,7 @@ Statement::Ptr::Ptr(const Statement::Ptr& aPtr) :
 /**
  * @brief Decrement the ref counter and finalize the sqlite3_stmt when it reaches 0
  */
-Statement::Ptr::~Ptr() noexcept // nothrow
+Statement::Ptr::~Ptr()
 {
     assert(NULL != mpRefCount);
     assert(0 != *mpRefCount);

--- a/src/Transaction.cpp
+++ b/src/Transaction.cpp
@@ -27,7 +27,7 @@ Transaction::Transaction(Database& aDatabase) :
 }
 
 // Safely rollback the transaction if it has not been committed.
-Transaction::~Transaction() noexcept // nothrow
+Transaction::~Transaction()
 {
     if (false == mbCommited)
     {


### PR DESCRIPTION
This is a pull request for "cleaning" the destructors.

I've removed the noexcept identifier since it is unnecessary.

Some destructor are empty, I leaved them since most where commented.

I've noticed that they are all declared virtual, but there are no virtual method in any class or any subclass. 
Is there a reason? Otherwise we could also remove the virtual identifier.