### PR TITLE
Remove virtual destructor since there are no virtual methods or subclasses

### DIFF
--- a/include/SQLiteCpp/Backup.h
+++ b/include/SQLiteCpp/Backup.h
@@ -100,7 +100,7 @@ public:
            Database& aSrcDatabase);
 
     /// Release the SQLite Backup resource.
-    virtual ~Backup();
+    ~Backup();
 
     /**
      * @brief Execute a step of backup with a given number of source pages to be copied

--- a/include/SQLiteCpp/Column.h
+++ b/include/SQLiteCpp/Column.h
@@ -54,7 +54,7 @@ public:
      */
     Column(Statement::Ptr& aStmtPtr, int aIndex)    noexcept; // nothrow
     /// Simple destructor
-    virtual ~Column();
+    ~Column();
 
     // default copy constructor and assignment operator are perfectly suited :
     // they copy the Statement::Ptr which in turn increments the reference counter.

--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -127,7 +127,7 @@ public:
      *
      * @warning assert in case of error
      */
-    virtual ~Database();
+    ~Database();
 
     /**
      * @brief Set a busy handler that sleeps for a specified amount of time when a table is locked.

--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -73,7 +73,7 @@ public:
     Statement(Database& aDatabase, const std::string& aQuery);
 
     /// Finalize and unregister the SQL query from the SQLite Database Connection.
-    virtual ~Statement();
+    ~Statement();
 
     /// Reset the statement to make it ready for a new execution.
     void reset();

--- a/include/SQLiteCpp/Transaction.h
+++ b/include/SQLiteCpp/Transaction.h
@@ -55,7 +55,7 @@ public:
     /**
      * @brief Safely rollback the transaction if it has not been committed.
      */
-    virtual ~Transaction();
+    ~Transaction();
 
     /**
      * @brief Commit the transaction.


### PR DESCRIPTION
As stated in https://github.com/SRombauts/SQLiteCpp/pull/139, virtual destructors have (currently) no use case