### PR TITLE
more cmake instructions for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,23 @@ The "CMakeLists.txt" file defining the static library is provided in the root di
 so you simply have to add_subdirectory(SQLiteCpp) to you main CMakeLists.txt
 and link to the "SQLiteCpp" wrapper library.
 
+Example for Linux: 
+```cmake
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/thirdparty/SQLiteCpp)
+
+INCLUDE_DIRECTORIES(
+  ${CMAKE_CURRENT_LIST_DIR}/thirdparty/SQLiteCpp/include
+)
+
+ADD_executable(main src/main.cpp)
+target_link_libraries(main
+  SQLiteCpp
+  sqlite3
+  pthread
+  dl
+  )
+  
+``` 
 Thus this SQLiteCpp repository can be directly used as a Git submoldule.
 See the [SQLiteCpp_Example](https://github.com/SRombauts/SQLiteCpp_Example) side repository for a standalone "from scratch" example.
 

--- a/README.md
+++ b/README.md
@@ -99,18 +99,17 @@ Example for Linux:
 ```cmake
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/thirdparty/SQLiteCpp)
 
-INCLUDE_DIRECTORIES(
+include_directories(
   ${CMAKE_CURRENT_LIST_DIR}/thirdparty/SQLiteCpp/include
 )
 
-ADD_executable(main src/main.cpp)
+add_executable(main src/main.cpp)
 target_link_libraries(main
   SQLiteCpp
   sqlite3
   pthread
   dl
   )
-  
 ``` 
 Thus this SQLiteCpp repository can be directly used as a Git submoldule.
 See the [SQLiteCpp_Example](https://github.com/SRombauts/SQLiteCpp_Example) side repository for a standalone "from scratch" example.


### PR DESCRIPTION
adding only SQLiteCpp to target_link_libraries() was not enough for me under ubuntu 16.04. 
there fore added cmake instructions in more detail.