### PR TITLE
Add a move constructor to Database

### DIFF
--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -120,6 +120,20 @@ public:
              const int          aBusyTimeoutMs  = 0,
              const std::string& aVfs            = "");
 
+#if __cplusplus >= 201103L
+    /**
+     * @brief Move an SQLite database connection.
+     *
+     * @param[in] aDb   Database to move
+     */
+    inline Database(Database&& aDb) noexcept :
+        mpSQLite(aDb.mpSQLite),
+        mFilename(std::move(aDb.mFilename))
+    {
+        aDb.mpSQLite = nullptr;
+    }
+#endif
+
     /**
      * @brief Close the SQLite database connection.
      *


### PR DESCRIPTION
This makes it possible to e.g. return Databases from functions. Gated behind a __cplusplus >= 201103L check for compatibility with older C++ versions. Defined inline due to its triviality and in order to avoid having to do the same preprocessor dance in two places.

Despite setting mpSQLite to null, there is no need to change the destructor, as sqlite3_close handles null pointers for us.