### PR TITLE
Exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build
 example1
 *.a
 
+.vscode/
 /SQLiteCpp.sln
 *.ncb
 *.suo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ set(SQLITECPP_INC
  ${PROJECT_SOURCE_DIR}/include/SQLiteCpp/Transaction.h
  ${PROJECT_SOURCE_DIR}/include/SQLiteCpp/Utils.h
  ${PROJECT_SOURCE_DIR}/include/SQLiteCpp/VariadicBind.h
+ ${PROJECT_SOURCE_DIR}/include/SQLiteCpp/ExecuteMany.h
 )
 source_group(include FILES ${SQLITECPP_INC})
 
@@ -141,6 +142,7 @@ set(SQLITECPP_TESTS
  tests/Transaction_test.cpp
  tests/VariadicBind_test.cpp
  tests/Exception_test.cpp
+ tests/ExecuteMany_test.cpp
 )
 source_group(tests FILES ${SQLITECPP_TESTS})
 
@@ -325,4 +327,3 @@ if (SQLITECPP_BUILD_TESTS)
 else (SQLITECPP_BUILD_TESTS)
     message(STATUS "SQLITECPP_BUILD_TESTS OFF")
 endif (SQLITECPP_BUILD_TESTS)
-

--- a/include/SQLiteCpp/ExecuteMany.h
+++ b/include/SQLiteCpp/ExecuteMany.h
@@ -1,0 +1,87 @@
+/**
+ * @file    ExecuteMany.h
+ * @ingroup SQLiteCpp
+ * @brief   Convenience function to execute a Statement with multiple Parameter sets
+ *
+ * Copyright (c) 2019 Maximilian Bachmann (github@maxbachmann)
+ *
+ * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
+ * or copy at http://opensource.org/licenses/MIT)
+ */
+#pragma once
+
+#if (__cplusplus >= 201402L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) ) // c++14: Visual Studio 2015
+
+#include <SQLiteCpp/Statement.h>
+#include <SQLiteCpp/VariadicBind.h>
+
+/// @cond
+#include <tuple>
+#include <utility>
+#include <initializer_list>
+
+namespace SQLite
+{
+/// @endcond
+
+/**
+ * \brief Convenience function to execute a Statement with multiple Parameter sets once for each parameter set given.
+ *
+ *
+ * This feature requires a c++14 capable compiler.
+ *
+ * \code{.cpp}
+ * execute_many(db, "INSERT INTO test VALUES (?, ?)",
+ *   std::make_tuple(1, "one"),
+ *   std::make_tuple(2, "two"),
+ *   std::make_tuple(3, "three")
+ * );
+ * \endcode
+ * @param aDatabase Database to use
+ * @param apQuery   Query to use with all parameter sets
+ * @param Arg       first tuple with parameters
+ * @param Types     the following tuples with parameters
+ */
+template <typename Arg, typename... Types>
+void execute_many(Database& aDatabase, const char* apQuery, Arg&& arg, Types&&... params) {
+    SQLite::Statement query(aDatabase, apQuery);
+    bind_exec(query, std::forward<decltype(arg)>(arg));
+    (void)std::initializer_list<int>{
+        ((void)reset_bind_exec(query, std::forward<decltype(params)>(params)), 0)...
+    };
+}
+
+/**
+ * \brief Convenience function to reset a statement and call bind_exec to 
+ * bind new values to the statement and execute it
+ *
+ * This feature requires a c++14 capable compiler.
+ *
+ * @param apQuery   Query to use
+ * @param tuple     tuple to bind
+ */
+template <typename ... Types>
+void reset_bind_exec(SQLite::Statement& query, std::tuple<Types...>&& tuple)
+{
+    query.reset();
+    bind_exec(query, std::forward<decltype(tuple)>(tuple));
+}
+
+/**
+ * \brief Convenience function to bind values a the statement and execute it
+ *
+ * This feature requires a c++14 capable compiler.
+ *
+ * @param apQuery   Query to use
+ * @param tuple     tuple to bind
+ */
+template <typename ... Types>
+void bind_exec(SQLite::Statement& query, std::tuple<Types...>&& tuple)
+{
+    bind(query, std::forward<decltype(tuple)>(tuple));
+    while (query.executeStep()) {}
+}
+
+}  // namespace SQLite
+
+#endif // c++14

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -260,7 +260,14 @@ bool Statement::executeStep()
     const int ret = tryExecuteStep();
     if ((SQLITE_ROW != ret) && (SQLITE_DONE != ret)) // on row or no (more) row ready, else it's a problem
     {
-        throw SQLite::Exception(mStmtPtr, ret);
+        if (ret == sqlite3_errcode(mStmtPtr))
+        {
+            throw SQLite::Exception(mStmtPtr, ret);
+        }
+        else
+        {
+            throw SQLite::Exception("Statement needs to be reseted", ret);
+        }
     }
 
     return mbHasRow; // true only if one row is accessible by getColumn(N)
@@ -270,15 +277,20 @@ bool Statement::executeStep()
 int Statement::exec()
 {
     const int ret = tryExecuteStep();
-    if (SQLITE_DONE != ret) // the statement has finished executing successfully
+    // the statement has finished executing successfully
+    if (SQLITE_DONE != ret) 
     {
         if (SQLITE_ROW == ret)
         {
             throw SQLite::Exception("exec() does not expect results. Use executeStep.");
         }
-        else
+        else if (ret == sqlite3_errcode(mStmtPtr))
         {
             throw SQLite::Exception(mStmtPtr, ret);
+        }
+        else
+        {
+            throw SQLite::Exception("Statement needs to be reseted", ret);
         }
     }
 

--- a/tests/ExecuteMany_test.cpp
+++ b/tests/ExecuteMany_test.cpp
@@ -1,0 +1,55 @@
+/**
+ * @file    VariadicBind_test.cpp
+ * @ingroup tests
+ * @brief   Test of variadic bind
+ *
+ * Copyright (c) 2016 Paul Dreik (github@pauldreik.se)
+ * Copyright (c) 2016-2019 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ * Copyright (c) 2019 Maximilian Bachmann (github@maxbachmann)
+ *
+ * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
+ * or copy at http://opensource.org/licenses/MIT)
+ */
+
+#include <SQLiteCpp/Database.h>
+#include <SQLiteCpp/Statement.h>
+#include <SQLiteCpp/ExecuteMany.h>
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+
+#if (__cplusplus >= 201402L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) ) // c++14: Visual Studio 2015
+TEST(ExecuteMany, invalid) {
+    // Create a new database
+    SQLite::Database db(":memory:", SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
+
+    EXPECT_EQ(0, db.exec("DROP TABLE IF EXISTS test"));
+    EXPECT_EQ(0,
+            db.exec(
+                    "CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT DEFAULT 'default') "));
+    EXPECT_TRUE(db.tableExists("test"));
+    {
+        execute_many(db, "INSERT INTO test VALUES (?, ?)",
+            std::make_tuple(1),
+            std::make_tuple(2, "two"),
+            std::make_tuple(3, "three")
+        );
+    }
+    // make sure the content is as expected
+    {
+        SQLite::Statement query(db, std::string{"SELECT id, value FROM test ORDER BY id"});
+        std::vector<std::pair<int, std::string> > results;
+        while (query.executeStep()) {
+            const int id = query.getColumn(0);
+            std::string value = query.getColumn(1);
+            results.emplace_back( id, std::move(value) );
+        }
+        EXPECT_EQ(std::size_t(3), results.size());
+
+        EXPECT_EQ(std::make_pair(1,std::string{""}), results.at(0));
+        EXPECT_EQ(std::make_pair(2,std::string{"two"}), results.at(1));
+        EXPECT_EQ(std::make_pair(3,std::string{"three"}), results.at(2));
+    }
+}
+#endif // c++14

--- a/tests/VariadicBind_test.cpp
+++ b/tests/VariadicBind_test.cpp
@@ -5,6 +5,7 @@
  *
  * Copyright (c) 2016 Paul Dreik (github@pauldreik.se)
  * Copyright (c) 2016-2019 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ * Copyright (c) 2019 Maximilian Bachmann (github@maxbachmann)
  *
  * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
  * or copy at http://opensource.org/licenses/MIT)
@@ -18,7 +19,7 @@
 
 #include <cstdio>
 
-#if (__cplusplus >= 201402L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) ) // c++14: Visual Studio 2015
+#if (__cplusplus >= 201103L) || ( defined(_MSC_VER) && (_MSC_VER >= 1800) ) // c++11: Visual Studio 2013
 TEST(VariadicBind, invalid) {
     // Create a new database
     SQLite::Database db(":memory:", SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
@@ -27,13 +28,14 @@ TEST(VariadicBind, invalid) {
     EXPECT_EQ(0,
             db.exec(
                     "CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT DEFAULT 'default') "));
+    EXPECT_EQ(0,
+            db.exec(
+                    "CREATE TABLE test2 (id INTEGER PRIMARY KEY, value TEXT DEFAULT 'default') "));
     EXPECT_TRUE(db.tableExists("test"));
+    EXPECT_TRUE(db.tableExists("test2"));
 
     {
         SQLite::Statement query(db, "INSERT INTO test VALUES (?, ?)");
-
-        // zero arguments - should give compile time error through a static assert
-        // SQLite::bind(query);
 
         // bind one argument less than expected - should be fine.
         // the unspecified argument should be set to null, not the default.
@@ -50,12 +52,9 @@ TEST(VariadicBind, invalid) {
         EXPECT_THROW(SQLite::bind(query, 3, "three", 0), SQLite::Exception);
         EXPECT_EQ(1, query.exec());
     }
-
     // make sure the content is as expected
     {
-        using namespace std::string_literals;
-
-        SQLite::Statement query(db, "SELECT id, value FROM test ORDER BY id"s);
+        SQLite::Statement query(db, std::string{"SELECT id, value FROM test ORDER BY id"});
         std::vector<std::pair<int, std::string> > results;
         while (query.executeStep()) {
             const int id = query.getColumn(0);
@@ -64,9 +63,44 @@ TEST(VariadicBind, invalid) {
         }
         EXPECT_EQ(std::size_t(3), results.size());
 
-        EXPECT_EQ(std::make_pair(1,""s), results.at(0));
-        EXPECT_EQ(std::make_pair(2,"two"s), results.at(1));
-        EXPECT_EQ(std::make_pair(3,"three"s), results.at(2));
+        EXPECT_EQ(std::make_pair(1,std::string{""}), results.at(0));
+        EXPECT_EQ(std::make_pair(2,std::string{"two"}), results.at(1));
+        EXPECT_EQ(std::make_pair(3,std::string{"three"}), results.at(2));
     }
+    #if (__cplusplus >= 201402L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) ) // c++14: Visual Studio 2015
+    {
+        SQLite::Statement query(db, "INSERT INTO test2 VALUES (?, ?)");
+
+        // bind one argument less than expected - should be fine.
+        // the unspecified argument should be set to null, not the default.
+        SQLite::bind(query, std::make_tuple(1));
+        EXPECT_EQ(1, query.exec());
+        query.reset();
+
+        // bind all arguments - should work just fine
+        SQLite::bind(query, std::make_tuple(2, "two"));
+        EXPECT_EQ(1, query.exec());
+        query.reset();
+
+        // bind too many arguments - should throw.
+        EXPECT_THROW(SQLite::bind(query, std::make_tuple(3, "three", 0)), SQLite::Exception);
+        EXPECT_EQ(1, query.exec());
+    }
+    // make sure the content is as expected
+    {
+        SQLite::Statement query(db, std::string{"SELECT id, value FROM test2 ORDER BY id"});
+        std::vector<std::pair<int, std::string> > results;
+        while (query.executeStep()) {
+            const int id = query.getColumn(0);
+            std::string value = query.getColumn(1);
+            results.emplace_back( id, std::move(value) );
+        }
+        EXPECT_EQ(std::size_t(3), results.size());
+
+        EXPECT_EQ(std::make_pair(1,std::string{""}), results.at(0));
+        EXPECT_EQ(std::make_pair(2,std::string{"two"}), results.at(1));
+        EXPECT_EQ(std::make_pair(3,std::string{"three"}), results.at(2));
+    }
+    #endif // c++14
 }
-#endif // c++14
+#endif // c++11


### PR DESCRIPTION
Fix issue #156
the problem is that tryExecuteStep returns SQLITE_MISUSE when it was not used properly. Since this is set manually this is not the error state of the statement, so when checking the error message of the statement there obviously is none, since there was no error. This problem can not only occur in the exec function, but in executeStep aswell when used improperly. This PR fixes this problem for both functions by checking whether the error code is the same as the error state of the statement