### PR TITLE
Fix Exception

### DIFF
--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -4,6 +4,7 @@
  * @brief   A prepared SQLite Statement is a compiled SQL query ready to be executed, pointing to a row of result.
  *
  * Copyright (c) 2012-2019 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ * Copyright (c) 2019 Maximilian Bachmann (github@maxbachmann)
  *
  * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
  * or copy at http://opensource.org/licenses/MIT)

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -260,7 +260,14 @@ bool Statement::executeStep()
     const int ret = tryExecuteStep();
     if ((SQLITE_ROW != ret) && (SQLITE_DONE != ret)) // on row or no (more) row ready, else it's a problem
     {
-        throw SQLite::Exception(mStmtPtr, ret);
+        if (ret == sqlite3_errcode(mStmtPtr))
+        {
+            throw SQLite::Exception(mStmtPtr, ret);
+        }
+        else
+        {
+            throw SQLite::Exception("Statement needs to be reseted", ret);
+        }
     }
 
     return mbHasRow; // true only if one row is accessible by getColumn(N)
@@ -276,9 +283,13 @@ int Statement::exec()
         {
             throw SQLite::Exception("exec() does not expect results. Use executeStep.");
         }
-        else
+        else if (ret == sqlite3_errcode(mStmtPtr))
         {
             throw SQLite::Exception(mStmtPtr, ret);
+        }
+        else
+        {
+            throw SQLite::Exception("Statement needs to be reseted", ret);
         }
     }
 


### PR DESCRIPTION
Fix issue #156
the problem is that tryExecuteStep returns SQLITE_MISUSE when it was not used properly. Since this is set manually this is not the error state of the statement, so when checking the error message of the statement there obviously is none, since there was no error. This problem can not only occur in the exec function, but in executeStep aswell when used improperly. This PR fixes this problem for both functions by checking whether the error code is the same as the error state of the statement