### PR TITLE
Add Statement::getExtendedSQL()

### DIFF
--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -608,6 +608,10 @@ public:
     {
         return mQuery;
     }
+
+    // Return a UTF-8 string containing the SQL text of prepared statement with bound parameters expanded.
+    std::string getExtendedSQL();
+
     /// Return the number of columns in the result set returned by the prepared statement
     inline int getColumnCount() const
     {

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -401,15 +401,22 @@ int Statement::getErrorCode() const noexcept // nothrow
 {
     return sqlite3_errcode(mStmtPtr);
 }
+
 // Return the extended numeric result code for the most recent failed API call (if any).
 int Statement::getExtendedErrorCode() const noexcept // nothrow
 {
     return sqlite3_extended_errcode(mStmtPtr);
 }
+
 // Return UTF-8 encoded English language explanation of the most recent failed API call (if any).
 const char* Statement::getErrorMsg() const noexcept // nothrow
 {
     return sqlite3_errmsg(mStmtPtr);
+}
+
+// Return a UTF-8 string containing the SQL text of prepared statement with bound parameters expanded.
+std::string Statement::getExtendedSQL() {
+    return sqlite3_expanded_sql(mStmtPtr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/Statement_test.cpp
+++ b/tests/Statement_test.cpp
@@ -252,6 +252,7 @@ TEST(Statement, bindings) {
         insert.bind(1, text);
         insert.bind(2, integer);
         insert.bind(3, dbl);
+        EXPECT_EQ(insert.getExtendedSQL(), "INSERT INTO test VALUES (NULL, 'first', -123, 0.123)");
         EXPECT_EQ(1, insert.exec());
         EXPECT_EQ(SQLITE_DONE, db.getErrorCode());
 


### PR DESCRIPTION
 - it returns a UTF-8 string containing the SQL text of prepared statement with
   bound parameters expanded