### PR TITLE
improve execute many

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -198,31 +198,30 @@ matrix:
         - CC=gcc-9
         - CXX=g++-9
         - CXXFLAGS="-std=c++14 -Wall -Wextra -pedantic"
-# TODO: issue with ExecuteMany and Bind helper function
-#    # gcc 9 std=c++17
-#    - compiler: gcc
-#      addons:
-#        apt:
-#          sources:
-#            - ubuntu-toolchain-r-test
-#          packages:
-#            - g++-9
-#      env:
-#        - CC=gcc-9
-#        - CXX=g++-9
-#        - CXXFLAGS="-std=c++17 -Wall -Wextra -pedantic"
-#    # gcc 9 std=c++2a
-#    - compiler: gcc
-#      addons:
-#        apt:
-#          sources:
-#            - ubuntu-toolchain-r-test
-#          packages:
-#            - g++-9
-#      env:
-#        - CC=gcc-9
-#        - CXX=g++-9
-#        - CXXFLAGS="-std=c++2a -Wall -Wextra -pedantic"
+    # gcc 9 std=c++17
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-9
+      env:
+        - CC=gcc-9
+        - CXX=g++-9
+        - CXXFLAGS="-std=c++17 -Wall -Wextra -pedantic"
+    # gcc 9 std=c++2a
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-9
+      env:
+        - CC=gcc-9
+        - CXX=g++-9
+        - CXXFLAGS="-std=c++2a -Wall -Wextra -pedantic"
     # clang default
     - compiler: clang
       env:

--- a/include/SQLiteCpp/ExecuteMany.h
+++ b/include/SQLiteCpp/ExecuteMany.h
@@ -44,9 +44,9 @@ namespace SQLite
  * @param aParams   the following tuples with parameters
  */
 template <typename Arg, typename... Types>
-void execute_many(Database& aDatabase, const char* apQuery, Arg&& aArg, Types&&... aParams)
+void execute_many(SQLite::Database& aDatabase, const char* apQuery, Arg&& aArg, Types&&... aParams)
 {
-    Statement query(aDatabase, apQuery);
+    SQLite::Statement query(aDatabase, apQuery);
     bind_exec(query, std::forward<Arg>(aArg));
     (void)std::initializer_list<int>
     {
@@ -64,7 +64,7 @@ void execute_many(Database& aDatabase, const char* apQuery, Arg&& aArg, Types&&.
  * @param aTuple    Tuple to bind
  */
 template <typename TupleT>
-void reset_bind_exec(Statement& apQuery, TupleT&& aTuple)
+void reset_bind_exec(SQLite::Statement& apQuery, TupleT&& aTuple)
 {
     apQuery.reset();
     bind_exec(apQuery, std::forward<TupleT>(aTuple));
@@ -79,9 +79,9 @@ void reset_bind_exec(Statement& apQuery, TupleT&& aTuple)
  * @param aTuple    Tuple to bind
  */
 template <typename TupleT>
-void bind_exec(Statement& apQuery, TupleT&& aTuple)
+void bind_exec(SQLite::Statement& apQuery, TupleT&& aTuple)
 {
-    bind(apQuery, std::forward<TupleT>(aTuple));
+    SQLite::bind(apQuery, std::forward<TupleT>(aTuple));
     while (apQuery.executeStep()) {}
 }
 

--- a/include/SQLiteCpp/ExecuteMany.h
+++ b/include/SQLiteCpp/ExecuteMany.h
@@ -33,8 +33,8 @@ namespace SQLite
  *
  * \code{.cpp}
  * execute_many(db, "INSERT INTO test VALUES (?, ?)",
- *   std::make_tuple(1, "one"),
- *   std::make_tuple(2, "two"),
+ *   1,
+ *   std::make_tuple(2),
  *   std::make_tuple(3, "three")
  * );
  * \endcode
@@ -46,11 +46,11 @@ namespace SQLite
 template <typename Arg, typename... Types>
 void execute_many(Database& aDatabase, const char* apQuery, Arg&& aArg, Types&&... aParams)
 {
-    SQLite::Statement query(aDatabase, apQuery);
-    bind_exec(query, std::forward<decltype(aArg)>(aArg));
+    Statement query(aDatabase, apQuery);
+    bind_exec(query, std::forward<Arg>(aArg));
     (void)std::initializer_list<int>
     {
-        ((void)reset_bind_exec(query, std::forward<decltype(aParams)>(aParams)), 0)...
+        ((void)reset_bind_exec(query, std::forward<Types>(aParams)), 0)...
     };
 }
 
@@ -63,11 +63,11 @@ void execute_many(Database& aDatabase, const char* apQuery, Arg&& aArg, Types&&.
  * @param apQuery   Query to use
  * @param aTuple    Tuple to bind
  */
-template <typename ... Types>
-void reset_bind_exec(SQLite::Statement& apQuery, std::tuple<Types...>&& aTuple)
+template <typename TupleT>
+void reset_bind_exec(Statement& apQuery, TupleT&& aTuple)
 {
     apQuery.reset();
-    bind_exec(apQuery, std::forward<decltype(aTuple)>(aTuple));
+    bind_exec(apQuery, std::forward<TupleT>(aTuple));
 }
 
 /**
@@ -78,10 +78,10 @@ void reset_bind_exec(SQLite::Statement& apQuery, std::tuple<Types...>&& aTuple)
  * @param apQuery   Query to use
  * @param aTuple    Tuple to bind
  */
-template <typename ... Types>
-void bind_exec(SQLite::Statement& apQuery, std::tuple<Types...>&& aTuple)
+template <typename TupleT>
+void bind_exec(Statement& apQuery, TupleT&& aTuple)
 {
-    bind(apQuery, std::forward<decltype(aTuple)>(aTuple));
+    bind(apQuery, std::forward<TupleT>(aTuple));
     while (apQuery.executeStep()) {}
 }
 

--- a/include/SQLiteCpp/ExecuteMany.h
+++ b/include/SQLiteCpp/ExecuteMany.h
@@ -3,7 +3,7 @@
  * @ingroup SQLiteCpp
  * @brief   Convenience function to execute a Statement with multiple Parameter sets
  *
- * Copyright (c) 2019 Maximilian Bachmann (github maxbachmann)
+ * Copyright (c) 2019 Maximilian Bachmann (contact@maxbachmann.de)
  * Copyright (c) 2019 Sebastien Rombauts (sebastien.rombauts@gmail.com)
  *
  * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt

--- a/include/SQLiteCpp/VariadicBind.h
+++ b/include/SQLiteCpp/VariadicBind.h
@@ -5,7 +5,7 @@
  *
  * Copyright (c) 2016 Paul Dreik (github@pauldreik.se)
  * Copyright (c) 2016-2019 Sebastien Rombauts (sebastien.rombauts@gmail.com)
- * Copyright (c) 2019 Maximilian Bachmann (github maxbachmann)
+ * Copyright (c) 2019 Maximilian Bachmann (contact@maxbachmann.de)
  *
  * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
  * or copy at http://opensource.org/licenses/MIT)

--- a/include/SQLiteCpp/VariadicBind.h
+++ b/include/SQLiteCpp/VariadicBind.h
@@ -77,7 +77,7 @@ void bind(SQLite::Statement& query, const Args& ... args)
 template <typename ... Types>
 void bind(SQLite::Statement& query, const std::tuple<Types...> &tuple)
 {
-    SQLite::bind(query, tuple, std::index_sequence_for<Types...>());
+    bind(query, tuple, std::index_sequence_for<Types...>());
 }
 
 /**
@@ -93,7 +93,7 @@ void bind(SQLite::Statement& query, const std::tuple<Types...> &tuple)
 template <typename ... Types, std::size_t ... Indices>
 void bind(SQLite::Statement& query, const std::tuple<Types...> &tuple, std::index_sequence<Indices...>)
 {
-    SQLite::bind(query, std::get<Indices>(tuple)...);
+    bind(query, std::get<Indices>(tuple)...);
 }
 #endif // c++14
 

--- a/include/SQLiteCpp/VariadicBind.h
+++ b/include/SQLiteCpp/VariadicBind.h
@@ -47,7 +47,7 @@ namespace SQLite
  * @param args      zero or more args to bind.
  */
 template<class ...Args>
-void bind(SQLite::Statement& query, const Args& ... args)
+void bind(Statement& query, const Args& ... args)
 {
     int pos = 0;
     (void)std::initializer_list<int>{
@@ -75,7 +75,7 @@ void bind(SQLite::Statement& query, const Args& ... args)
  * @param tuple     tuple with values to bind
  */
 template <typename ... Types>
-void bind(SQLite::Statement& query, const std::tuple<Types...> &tuple)
+void bind(Statement& query, const std::tuple<Types...> &tuple)
 {
     bind(query, tuple, std::index_sequence_for<Types...>());
 }
@@ -91,7 +91,7 @@ void bind(SQLite::Statement& query, const std::tuple<Types...> &tuple)
  * @param tuple     tuple with values to bind
  */
 template <typename ... Types, std::size_t ... Indices>
-void bind(SQLite::Statement& query, const std::tuple<Types...> &tuple, std::index_sequence<Indices...>)
+void bind(Statement& query, const std::tuple<Types...> &tuple, std::index_sequence<Indices...>)
 {
     bind(query, std::get<Indices>(tuple)...);
 }

--- a/include/SQLiteCpp/VariadicBind.h
+++ b/include/SQLiteCpp/VariadicBind.h
@@ -47,7 +47,7 @@ namespace SQLite
  * @param args      zero or more args to bind.
  */
 template<class ...Args>
-void bind(Statement& query, const Args& ... args)
+void bind(SQLite::Statement& query, const Args& ... args)
 {
     int pos = 0;
     (void)std::initializer_list<int>{
@@ -75,9 +75,9 @@ void bind(Statement& query, const Args& ... args)
  * @param tuple     tuple with values to bind
  */
 template <typename ... Types>
-void bind(Statement& query, const std::tuple<Types...> &tuple)
+void bind(SQLite::Statement& query, const std::tuple<Types...> &tuple)
 {
-    bind(query, tuple, std::index_sequence_for<Types...>());
+    SQLite::bind(query, tuple, std::index_sequence_for<Types...>());
 }
 
 /**
@@ -91,9 +91,9 @@ void bind(Statement& query, const std::tuple<Types...> &tuple)
  * @param tuple     tuple with values to bind
  */
 template <typename ... Types, std::size_t ... Indices>
-void bind(Statement& query, const std::tuple<Types...> &tuple, std::index_sequence<Indices...>)
+void bind(SQLite::Statement& query, const std::tuple<Types...> &tuple, std::index_sequence<Indices...>)
 {
-    bind(query, std::get<Indices>(tuple)...);
+    SQLite::bind(query, std::get<Indices>(tuple)...);
 }
 #endif // c++14
 

--- a/tests/ExecuteMany_test.cpp
+++ b/tests/ExecuteMany_test.cpp
@@ -29,8 +29,8 @@ TEST(ExecuteMany, invalid)
     EXPECT_TRUE(db.tableExists("test"));
     {
         execute_many(db, "INSERT INTO test VALUES (?, ?)",
-            std::make_tuple(1),
-            std::make_tuple(2, "two"),
+            1,
+            std::make_tuple(2),
             std::make_tuple(3, "three")
         );
     }
@@ -47,7 +47,7 @@ TEST(ExecuteMany, invalid)
         EXPECT_EQ(std::size_t(3), results.size());
 
         EXPECT_EQ(std::make_pair(1,std::string{""}), results.at(0));
-        EXPECT_EQ(std::make_pair(2,std::string{"two"}), results.at(1));
+        EXPECT_EQ(std::make_pair(2,std::string{""}), results.at(1));
         EXPECT_EQ(std::make_pair(3,std::string{"three"}), results.at(2));
     }
 }


### PR DESCRIPTION
execute many can handle different types now aswell and not only tuples.
This way it does not require the user to create a tuple to bind a single value:
```cpp
execute_many(db, "INSERT INTO test VALUES (?, ?)",
            1,
            std::make_tuple(2),
            std::make_tuple(3, "three")
        );
```

currently this means it supports tuples and single values when only one value has to be bound, since these are the only types supported by VariadicBind right now