### PR TITLE
Disable cast-function-type warning when building internal sqlite

### DIFF
--- a/sqlite3/CMakeLists.txt
+++ b/sqlite3/CMakeLists.txt
@@ -15,6 +15,11 @@ if (UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Cla
     set_target_properties(sqlite3 PROPERTIES COMPILE_FLAGS "-fPIC")
 endif (UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))
 
-if (UNIX AND CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
-    target_compile_options(sqlite3 PRIVATE "-Wimplicit-fallthrough=0")
+if (UNIX AND CMAKE_COMPILER_IS_GNUCXX)
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
+        target_compile_options(sqlite3 PRIVATE "-Wimplicit-fallthrough=0")
+    endif()
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
+        target_compile_options(sqlite3 PRIVATE "-Wno-cast-function-type")
+    endif()
 endif()


### PR DESCRIPTION
Disables cast-function-type warning which is available in gcc 8.0 and greater.