### PR TITLE
Explicitly find and link against system sqlite library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,12 +206,6 @@ install(EXPORT ${PROJECT_NAME}Config DESTINATION lib/cmake/${PROJECT_NAME})
 
 ## Build provided copy of SQLite3 C library ##
 
-# TODO 
-#find_package(sqlite3)
-#if(sqlite3_VERSION VERSION_LESS "3.19")
-#    set_target_properties(SQLiteCpp PROPERTIES COMPILE_FLAGS "-DSQLITECPP_HAS_MEM_STRUCT")
-#endif()
-
 option(SQLITECPP_USE_ASAN "Use Address Sanitizer." OFF)
 if (SQLITECPP_USE_ASAN)
     if ((CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 6) OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
@@ -230,6 +224,12 @@ if (SQLITECPP_INTERNAL_SQLITE)
     add_subdirectory(sqlite3)
     target_include_directories(sqlite3 PUBLIC "${PROJECT_SOURCE_DIR}/sqlite3")
     target_include_directories(SQLiteCpp PRIVATE "${PROJECT_SOURCE_DIR}/sqlite3")
+else (SQLITECPP_INTERNAL_SQLITE)
+    find_package (SQLite3 REQUIRED)
+    if (SQLITE3_FOUND)
+        include_directories(${SQLITE3_INCLUDE_DIRS})
+        target_link_libraries (SQLiteCpp ${SQLITE3_LIBRARIES})
+    endif (SQLITE3_FOUND)
 endif (SQLITECPP_INTERNAL_SQLITE)
 
 # Optional additional targets:


### PR DESCRIPTION
Explicitly find and link against system sqlite library when built with `-SQLITECPP_INTERNAL_SQLITE=OFF`.

This will fix -as-needed linker issue:

```text
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_column_text
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_close
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_column_int
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_reset
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_bind_int
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_total_changes
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_clear_bindings
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_open_v2
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_column_bytes
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_bind_null
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_exec
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_extended_errcode
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_backup_step
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_free
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_backup_remaining
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_db_config
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_bind_double
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_backup_init
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_column_int64
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_bind_int64
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_finalize
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_column_type
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_errcode
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_changes
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_bind_text
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_column_origin_name
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_step
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_backup_finish
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_column_count
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_create_function_v2
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_errstr
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_errmsg
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_load_extension
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_column_name
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_column_blob
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_bind_parameter_index
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_libversion
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_prepare_v2
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_backup_pagecount
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_libversion_number
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_busy_timeout
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_column_double
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_bind_blob
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_bind_parameter_count
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_open
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_expanded_sql
sqlitecpp.x86_64: W: undefined-non-weak-symbol /usr/lib64/libSQLiteCpp.so.0
sqlite3_last_insert_rowid
```