### PR TITLE
Added SOVERSION field for shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,3 +345,6 @@ if (SQLITECPP_BUILD_TESTS)
 else (SQLITECPP_BUILD_TESTS)
     message(STATUS "SQLITECPP_BUILD_TESTS OFF")
 endif (SQLITECPP_BUILD_TESTS)
+
+# API version for SQLiteCpp shared library.
+set_property(TARGET SQLiteCpp PROPERTY SOVERSION 0)


### PR DESCRIPTION
Most of GNU/Linux distributions require SOVERSION field of shared library to be set.

You should bump SOVERSION every time you draft a new release with breaking API changes.