### PR TITLE
Disable explicit setting of MSVC runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 message (STATUS "CMake version: ${CMAKE_VERSION}")
 message (STATUS "Project version: ${PROJECT_VERSION}")
 
+option(SQLITECPP_USE_STATIC_RUNTIME "Use MSVC static runtime (default for internal googletest)." ON)
+
 # Define useful variables to handle OS differences:
 if (WIN32)
     set(DEV_NULL                "NUL")
@@ -28,14 +30,14 @@ if (MSVC)
     set(CPPCHECK_ARG_TEMPLATE   "--template=vs")
     # disable Visual Studio warnings for fopen() used in the example
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-    # Flags for linking with multithread static C++ runtime, required by googletest
-    if (SQLITECPP_BUILD_TESTS)
-        message(STATUS "Linking against multithread static C++ runtime for unit tests with googletest")
+    # Flags for linking with multithread static C++ runtime, required by internal googletest
+    if (SQLITECPP_USE_STATIC_RUNTIME)
+        message(STATUS "Linking against multithread static C++ runtime")
         set(CMAKE_C_FLAGS_RELEASE   "${CMAKE_C_FLAGS_RELEASE} /MT")
         set(CMAKE_C_FLAGS_DEBUG     "${CMAKE_C_FLAGS_DEBUG} /MTd")
         set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
         set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
-    endif (SQLITECPP_BUILD_TESTS)
+    endif (SQLITECPP_USE_STATIC_RUNTIME)
     # MSVC versions prior to 2015 are not supported anymore by SQLiteC++ 3.x
     if (MSVC_VERSION LESS 1900) # OR MSVC_TOOLSET_VERSION LESS 140)
       message(ERROR "Visual Studio prior to 2015 is not supported anymore.")


### PR DESCRIPTION
This PR removes the explicit setting of the MSVC runtime from SQLiteCpp. This is because overriding the default runtime can have various negative implications. For example, the build of SQLiteCpp fails on MSVC 2019 with errors:
```
LINK : warning LNK4098: defaultlib 'MSVCRTD' conflicts with use of other libs; use /NODEFAULTLIB:library
LINK : warning LNK4217: symbol 'free' defined in 'libucrtd.lib(free.obj)' is imported by 'sqlite3.lib(sqlite3.c.obj)' in function 'vfsUnlink'
LINK : warning LNK4217: symbol 'malloc' defined in 'libucrtd.lib(malloc.obj)' is imported by 'sqlite3.lib(sqlite3.c.obj)' in function 'vfsUnlink'
LINK : warning LNK4217: symbol '__acrt_iob_func' defined in 'libucrtd.lib(_file.obj)' is imported by 'sqlite3.lib(sqlite3.c.obj)' in function 'sqlite3VdbePrintOp'
LINK : warning LNK4217: symbol 'fflush' defined in 'libucrtd.lib(fflush.obj)' is imported by 'sqlite3.lib(sqlite3.c.obj)' in function 'sqlite3VdbePrintOp'
LINK : warning LNK4217: symbol '__stdio_common_vfprintf' defined in 'libucrtd.lib(output.obj)' is imported by 'sqlite3.lib(sqlite3.c.obj)' in function '_vfprintf_l'
LINK : warning LNK4217: symbol 'strcspn' defined in 'libucrtd.lib(strcspn.obj)' is imported by 'sqlite3.lib(sqlite3.c.obj)' in function 'patternCompare'
LINK : warning LNK4217: symbol 'strncmp' defined in 'libucrtd.lib(strncmp.obj)' is imported by 'sqlite3.lib(sqlite3.c.obj)' in function 'sqlite3VListNameToNum'
LINK : warning LNK4217: symbol '_wassert' defined in 'libucrtd.lib(assert.obj)' is imported by 'sqlite3.lib(sqlite3.c.obj)' in function 'sqlite3CompileOptions'
sqlite3.lib(sqlite3.c.obj) : error LNK2019: unresolved external symbol __imp__msize referenced in function vfsUnlink
sqlite3.lib(sqlite3.c.obj) : error LNK2019: unresolved external symbol __imp_realloc referenced in function vfsUnlink
sqlite3.lib(sqlite3.c.obj) : error LNK2019: unresolved external symbol __imp__localtime64_s referenced in function localtime_s
sqlite3.lib(sqlite3.c.obj) : error LNK2019: unresolved external symbol __imp__beginthreadex referenced in function sqlite3ThreadCreate
sqlite3.lib(sqlite3.c.obj) : error LNK2019: unresolved external symbol __imp__endthreadex referenced in function sqlite3ThreadProc
SQLiteCpp_example1.exe : fatal error LNK1120: 5 unresolved externals
```

This error is resolved by the PR.