### PR TITLE
Added SQLite header parsing functionality and associated tests

### DIFF
--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -12,7 +12,7 @@
 
 #include <SQLiteCpp/Column.h>
 #include <SQLiteCpp/Utils.h>    // definition of nullptr for C++98/C++03 compilers
-
+#include <cstdint>
 #include <string.h>
 
 // Forward declarations to avoid inclusion of <sqlite3.h> in a header
@@ -53,6 +53,32 @@ const char* getLibVersion() noexcept; // nothrow
 /// Return SQLite version number using runtime call to the compiled library
 int   getLibVersionNumber() noexcept; // nothrow
 
+// Public structure for representing all fields contained within the SQLite header.
+// Official documentation for fields: https://www.sqlite.org/fileformat.html#the_database_header
+struct Header {
+    unsigned char headerStr[16];
+    uint16_t pageSizeBytes;
+    unsigned char fileFormatWriteVersion;
+    unsigned char fileFormatReadVersion;
+    unsigned char reservedSpaceBytes;
+    unsigned char maxEmbeddedPayloadFrac;
+    unsigned char minEmbeddedPayloadFrac;
+    unsigned char leafPayloadFrac;
+    uint32_t fileChangeCounter;
+    uint32_t databaseSizePages;
+    uint32_t firstFreelistTrunkPage;
+    uint32_t totalFreelistPages;
+    uint32_t schemaCookie;
+    uint32_t schemaFormatNumber;
+    uint32_t defaultPageCacheSizeBytes;
+    uint32_t largestBTreePageNumber;
+    uint32_t databaseTextEncoding;
+    uint32_t userVersion;
+    uint32_t incrementalVaccumMode;
+    uint32_t applicationId;
+    uint32_t versionValidFor;
+    uint32_t sqliteVersion;
+};
 
 /**
  * @brief RAII management of a SQLite Database Connection.
@@ -433,6 +459,21 @@ public:
     * @throw SQLite::Exception in case of error
     */
     static bool isUnencrypted(const std::string& aFilename);
+
+    /**
+    * @brief Parse SQLite header data from a database file.
+    *
+    *  This function reads the first 100 bytes of a SQLite database file
+    *  and reconstructs groups of individual bytes into the associated fields
+    *  in a Header object.
+    *  
+    * @param[in] aFilename path/uri to a file
+    *
+    * @return Header object containing file data
+    *
+    * @throw SQLite::Exception in case of error
+    */
+    static Header getHeaderInfo(const std::string& aFilename);
 
     /**
      * @brief BackupType for the backup() method

--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -12,7 +12,6 @@
 
 #include <SQLiteCpp/Column.h>
 #include <SQLiteCpp/Utils.h>    // definition of nullptr for C++98/C++03 compilers
-#include <cstdint>
 #include <string.h>
 
 // Forward declarations to avoid inclusion of <sqlite3.h> in a header
@@ -57,27 +56,27 @@ int   getLibVersionNumber() noexcept; // nothrow
 // Official documentation for fields: https://www.sqlite.org/fileformat.html#the_database_header
 struct Header {
     unsigned char headerStr[16];
-    uint16_t pageSizeBytes;
+    unsigned int pageSizeBytes;
     unsigned char fileFormatWriteVersion;
     unsigned char fileFormatReadVersion;
     unsigned char reservedSpaceBytes;
     unsigned char maxEmbeddedPayloadFrac;
     unsigned char minEmbeddedPayloadFrac;
     unsigned char leafPayloadFrac;
-    uint32_t fileChangeCounter;
-    uint32_t databaseSizePages;
-    uint32_t firstFreelistTrunkPage;
-    uint32_t totalFreelistPages;
-    uint32_t schemaCookie;
-    uint32_t schemaFormatNumber;
-    uint32_t defaultPageCacheSizeBytes;
-    uint32_t largestBTreePageNumber;
-    uint32_t databaseTextEncoding;
-    uint32_t userVersion;
-    uint32_t incrementalVaccumMode;
-    uint32_t applicationId;
-    uint32_t versionValidFor;
-    uint32_t sqliteVersion;
+    unsigned long fileChangeCounter;
+    unsigned long  databaseSizePages;
+    unsigned long firstFreelistTrunkPage;
+    unsigned long totalFreelistPages;
+    unsigned long schemaCookie;
+    unsigned long schemaFormatNumber;
+    unsigned long defaultPageCacheSizeBytes;
+    unsigned long largestBTreePageNumber;
+    unsigned long databaseTextEncoding;
+    unsigned long userVersion;
+    unsigned long incrementalVaccumMode;
+    unsigned long applicationId;
+    unsigned long versionValidFor;
+    unsigned long sqliteVersion;
 };
 
 /**

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -305,130 +305,128 @@ Header Database::getHeaderInfo(const std::string& aFilename)
 {
     Header h;
     unsigned char buf[100];
+    char* pBuf = reinterpret_cast<char*>(&buf[0]);
+    char* pHeaderStr = reinterpret_cast<char*>(&h.headerStr[0]);
 
-    if (aFilename.length() > 0 )
+    if (aFilename.empty())
     {
-
-        std::ifstream fileBuffer(aFilename.c_str(), std::ios::in | std::ios::binary);
-
-        if (fileBuffer.is_open())
-        {
-            fileBuffer.seekg(0, std::ios::beg);
-            fileBuffer.read(reinterpret_cast<char*>(&buf[0]), 100);
-            fileBuffer.close();
-            strncpy(reinterpret_cast<char*>(&h.headerStr[0]), reinterpret_cast<char*>(buf), 16);
-        }
-
-        else
-        {
-            const SQLite::Exception exception("Error opening file: " + aFilename);
-            throw exception;
-        }
-
-        // If the "magic string" can't be found then header is invalid, corrupt or unreadable
-        if (!strncmp(reinterpret_cast<const char*>(h.headerStr), "SQLite format 3", 15) == 0)
-        {
-            const SQLite::Exception exception("Invalid SQLite header");
-            throw exception;
-        }
-
-        h.pageSizeBytes = (buf[16] << 8) | buf[17];
-        h.fileFormatWriteVersion = buf[18];
-        h.fileFormatReadVersion = buf[19];
-        h.reservedSpaceBytes = buf[20];
-        h.maxEmbeddedPayloadFrac = buf[21];
-        h.minEmbeddedPayloadFrac = buf[22];
-        h.leafPayloadFrac = buf[23];
-
-        h.fileChangeCounter =
-            (buf[24] << 24) |
-            (buf[25] << 16) |
-            (buf[26] << 8)  |
-            (buf[27] << 0);
-
-        h.databaseSizePages =
-            (buf[28] << 24) |
-            (buf[29] << 16) |
-            (buf[30] << 8)  |
-            (buf[31] << 0);
-
-        h.firstFreelistTrunkPage =
-            (buf[32] << 24) |
-            (buf[33] << 16) |
-            (buf[34] << 8)  |
-            (buf[35] << 0);
-
-        h.totalFreelistPages =
-            (buf[36] << 24) |
-            (buf[37] << 16) |
-            (buf[38] << 8)  |
-            (buf[39] << 0);
-
-        h.schemaCookie =
-            (buf[40] << 24) |
-            (buf[41] << 16) |
-            (buf[42] << 8)  |
-            (buf[43] << 0);
-
-        h.schemaFormatNumber =
-            (buf[44] << 24) |
-            (buf[45] << 16) |
-            (buf[46] << 8)  |
-            (buf[47] << 0);
-
-        h.defaultPageCacheSizeBytes =
-            (buf[48] << 24) |
-            (buf[49] << 16) |
-            (buf[50] << 8)  |
-            (buf[51] << 0);
-
-        h.largestBTreePageNumber =
-            (buf[52] << 24) |
-            (buf[53] << 16) |
-            (buf[54] << 8)  |
-            (buf[55] << 0);
-
-        h.databaseTextEncoding =
-            (buf[56] << 24) |
-            (buf[57] << 16) |
-            (buf[58] << 8)  |
-            (buf[59] << 0);
-
-        h.userVersion =
-            (buf[60] << 24) |
-            (buf[61] << 16) |
-            (buf[62] << 8)  |
-            (buf[63] << 0);
-
-        h.incrementalVaccumMode =
-            (buf[64] << 24) |
-            (buf[65] << 16) |
-            (buf[66] << 8)  |
-            (buf[67] << 0);
-
-        h.applicationId =
-            (buf[68] << 24) |
-            (buf[69] << 16) |
-            (buf[70] << 8)  |
-            (buf[71] << 0);
-
-        h.versionValidFor =
-            (buf[92] << 24) |
-            (buf[93] << 16) |
-            (buf[94] << 8)  |
-            (buf[95] << 0);
-
-        h.sqliteVersion =
-            (buf[96] << 24) |
-            (buf[97] << 16) |
-            (buf[98] << 8)  |
-            (buf[99] << 0);
-
-        return h;
+        throw SQLite::Exception("Could not open database, the aFilename parameter was empty.");
     }
 
-    const SQLite::Exception exception("Could not open database, the aFilename parameter was empty.");
-    throw exception;
+    std::ifstream fileBuffer(aFilename.c_str(), std::ios::in | std::ios::binary);
+
+    if (fileBuffer.is_open())
+    {
+        fileBuffer.seekg(0, std::ios::beg);
+        fileBuffer.read(pBuf, 100);
+        fileBuffer.close();
+        strncpy(pHeaderStr, pBuf, 16);
+    }
+
+    else
+    {
+        throw SQLite::Exception("Error opening file: " + aFilename);
+    }
+
+    // If the "magic string" can't be found then header is invalid, corrupt or unreadable
+    if (!strncmp(pHeaderStr, "SQLite format 3", 15) == 0)
+    {
+        throw SQLite::Exception("Invalid or encrypted SQLite header");
+    }
+
+    h.pageSizeBytes = (buf[16] << 8) | buf[17];
+    h.fileFormatWriteVersion = buf[18];
+    h.fileFormatReadVersion = buf[19];
+    h.reservedSpaceBytes = buf[20];
+    h.maxEmbeddedPayloadFrac = buf[21];
+    h.minEmbeddedPayloadFrac = buf[22];
+    h.leafPayloadFrac = buf[23];
+
+    h.fileChangeCounter =
+        (buf[24] << 24) |
+        (buf[25] << 16) |
+        (buf[26] << 8)  |
+        (buf[27] << 0);
+
+    h.databaseSizePages =
+        (buf[28] << 24) |
+        (buf[29] << 16) |
+        (buf[30] << 8)  |
+        (buf[31] << 0);
+
+    h.firstFreelistTrunkPage =
+        (buf[32] << 24) |
+        (buf[33] << 16) |
+        (buf[34] << 8)  |
+        (buf[35] << 0);
+
+    h.totalFreelistPages =
+        (buf[36] << 24) |
+        (buf[37] << 16) |
+        (buf[38] << 8)  |
+        (buf[39] << 0);
+
+    h.schemaCookie =
+        (buf[40] << 24) |
+        (buf[41] << 16) |
+        (buf[42] << 8)  |
+        (buf[43] << 0);
+
+    h.schemaFormatNumber =
+        (buf[44] << 24) |
+        (buf[45] << 16) |
+        (buf[46] << 8)  |
+        (buf[47] << 0);
+
+    h.defaultPageCacheSizeBytes =
+        (buf[48] << 24) |
+        (buf[49] << 16) |
+        (buf[50] << 8)  |
+        (buf[51] << 0);
+
+    h.largestBTreePageNumber =
+        (buf[52] << 24) |
+        (buf[53] << 16) |
+        (buf[54] << 8)  |
+        (buf[55] << 0);
+
+    h.databaseTextEncoding =
+        (buf[56] << 24) |
+        (buf[57] << 16) |
+        (buf[58] << 8)  |
+        (buf[59] << 0);
+
+    h.userVersion =
+        (buf[60] << 24) |
+        (buf[61] << 16) |
+        (buf[62] << 8)  |
+        (buf[63] << 0);
+
+    h.incrementalVaccumMode =
+        (buf[64] << 24) |
+        (buf[65] << 16) |
+        (buf[66] << 8)  |
+        (buf[67] << 0);
+
+    h.applicationId =
+        (buf[68] << 24) |
+        (buf[69] << 16) |
+        (buf[70] << 8)  |
+        (buf[71] << 0);
+
+    h.versionValidFor =
+        (buf[92] << 24) |
+        (buf[93] << 16) |
+        (buf[94] << 8)  |
+        (buf[95] << 0);
+
+    h.sqliteVersion =
+        (buf[96] << 24) |
+        (buf[97] << 16) |
+        (buf[98] << 8)  |
+        (buf[99] << 0);
+
+    return h;
 }
 
 

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -16,7 +16,6 @@
 
 #include <sqlite3.h>
 #include <fstream>
-#include <vector>
 #include <string.h>
 
 #ifndef SQLITE_DETERMINISTIC

--- a/tests/Database_test.cpp
+++ b/tests/Database_test.cpp
@@ -283,7 +283,7 @@ TEST(Database, execException)
     EXPECT_THROW(db.exec("INSERT INTO test VALUES (NULL, \"first\",  3)"), SQLite::Exception);
     EXPECT_EQ(SQLITE_ERROR, db.getErrorCode());
     EXPECT_EQ(SQLITE_ERROR, db.getExtendedErrorCode());
-    EXPECT_STREQ("no such table: test", db.getErrorMsg());remove("test.db3");
+    EXPECT_STREQ("no such table: test", db.getErrorMsg());
 
     // Create a new table
     db.exec("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT, weight INTEGER)");

--- a/tests/Database_test.cpp
+++ b/tests/Database_test.cpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdio>
+#include <fstream>
 
 #ifdef SQLITECPP_ENABLE_ASSERT_HANDLER
 namespace SQLite
@@ -318,6 +319,22 @@ TEST(Database, getHeaderInfo)
 {
     remove("test.db3");
     {
+        //Call without passing a database file name
+        EXPECT_THROW(SQLite::Database::getHeaderInfo(""),SQLite::Exception);
+
+        //Call with a non existant database
+        EXPECT_THROW(SQLite::Database::getHeaderInfo("test.db3"), SQLite::Exception);
+
+        //Simulate a corrupt header by writing garbage to a file
+        unsigned char badData[100];
+        std::ofstream corruptDb;
+        corruptDb.open("corrupt.db3", std::ios::app | std::ios::binary);
+        corruptDb.write(reinterpret_cast<char*>(&badData), sizeof(badData));
+
+        EXPECT_THROW(SQLite::Database::getHeaderInfo("corrupt.db3"), SQLite::Exception);
+        
+        remove("corrupt.db3");
+
         // Create a new database
         SQLite::Database db("test.db3", SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
         db.exec("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)");

--- a/tests/Database_test.cpp
+++ b/tests/Database_test.cpp
@@ -327,9 +327,11 @@ TEST(Database, getHeaderInfo)
 
         //Simulate a corrupt header by writing garbage to a file
         unsigned char badData[100];
+        char* pBadData = reinterpret_cast<char*>(&badData[0]);
+
         std::ofstream corruptDb;
         corruptDb.open("corrupt.db3", std::ios::app | std::ios::binary);
-        corruptDb.write(reinterpret_cast<char*>(&badData), sizeof(badData));
+        corruptDb.write(pBadData, 100);
 
         EXPECT_THROW(SQLite::Database::getHeaderInfo("corrupt.db3"), SQLite::Exception);
         


### PR DESCRIPTION
Added header parsing functionality via a `getHeaderInfo()` function. This function reads the first 100 bytes of a SQLite database file and attempts to reconstruct byte groups into the specific header fields within a Header object. Also added tests to demonstrate updating header values via PRAGMA and verifying updated / default header values. 