### PR TITLE
Add an example2 based on SQLiteCpp_Example repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           }
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: submodule
       run: git submodule update --init --recursive
     - name: configure

--- a/.github/workflows/subdir_example.yml
+++ b/.github/workflows/subdir_example.yml
@@ -1,0 +1,48 @@
+name: subdir_example
+
+on: [push]
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name: "Windows Latest MSVC",
+            os: windows-latest,
+            build_type: "Debug", cc: "cl", cxx: "cl",
+          }
+        - {
+            name: "Ubuntu Latest GCC",
+            os: ubuntu-latest,
+            build_type: "Debug", cc: "gcc", cxx: "g++"
+          }
+        - {
+            name: "Ubuntu 16.04 GCC",
+            os: ubuntu-16.04,
+            build_type: "Debug", cc: "gcc", cxx: "g++"
+          }
+        - {
+            name: "macOS Latest Clang",
+            os: macos-latest,
+            build_type: "Debug", cc: "clang", cxx: "clang++"
+          }
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: configure
+      shell: cmake -P {0}
+      run: |
+        set(ENV{CC} ${{matrix.config.cc}})
+        set(ENV{CXX} ${{matrix.config.cxx}})
+    - name: generate
+      run: |
+        cd examples/example2
+        mkdir build
+        cd build
+        cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=${{matrix.config.build_type}} .. 
+    - name: build
+      run: cmake --build examples/example2/build --config ${{matrix.config.build_type}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # or copy at http://opensource.org/licenses/MIT)
 cmake_minimum_required(VERSION 3.1) # for "CMAKE_CXX_STANDARD" version
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake") # custom CMake modules like FindSQLiteCpp
-project(SQLiteCpp VERSION "2.99")
+project(SQLiteCpp VERSION 2.99)
 
 # SQLiteC++ 3.x now requires C++11 compiler
 set(CMAKE_CXX_STANDARD 11)
@@ -145,7 +145,8 @@ source_group(doc FILES ${SQLITECPP_DOC})
 set(SQLITECPP_SCRIPT
  .editorconfig
  .gitbugtraq
- .github/workflows/actions.yml
+ .github/workflows/build.yml
+ .github/workflows/subdir_example.yml
  .gitignore
  .gitmodules
  .travis.yml

--- a/examples/example2/CMakeLists.txt
+++ b/examples/example2/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Example CMake file for compiling & linking a project with the the SQLiteCpp wrapper
+#
+# Copyright (c) 2012-2020 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+#
+# Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
+# or copy at http://opensource.org/licenses/MIT) 
+cmake_minimum_required(VERSION 3.1) # for "CMAKE_CXX_STANDARD" version
+project(SQLiteCpp_Example VERSION 2.0)
+
+# SQLiteC++ 3.x now requires C++11 compiler
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Add SQLite3 C++ wrapper around sqlite3 library (and sqlite3 itself provided for ease of use)
+# Here you can set CMake variables to avoid building Example, as well as cpplint, cppcheck...
+# or set them in the cmake command line (see for instance provided build.bat/build.sh scripts)
+set(SQLITECPP_RUN_CPPCHECK OFF CACHE BOOL "" FORCE)
+set(SQLITECPP_RUN_CPPLINT OFF CACHE BOOL "" FORCE)
+add_subdirectory(../.. SQLiteCpp) # out-of-source build requires explicit subdir name for compilation artifacts
+
+# Add main.cpp example source code to the executable
+add_executable(SQLiteCpp_Example src/main.cpp)
+
+# Link SQLiteCpp_example1 with SQLiteCpp
+target_link_libraries(SQLiteCpp_Example SQLiteCpp)

--- a/examples/example2/README.md
+++ b/examples/example2/README.md
@@ -1,0 +1,3 @@
+SQLiteCpp_Example demonstrates how to use SQLiteCpp as a subdirectory of a CMake project.
+
+See https://github.com/SRombauts/SQLiteCpp_Example

--- a/examples/example2/build.bat
+++ b/examples/example2/build.bat
@@ -1,0 +1,21 @@
+@REM Copyright (c) 2012-2020 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+@REM
+@REM Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
+@REM or copy at http://opensource.org/licenses/MIT)
+mkdir build
+cd build
+
+@REM Generate a Visual Studio solution for latest version found
+cmake ..
+@if ERRORLEVEL 1 goto onError
+
+@REM Build default configuration (ie 'Debug')
+cmake --build .
+@if ERRORLEVEL 1 goto onError
+
+goto onSuccess
+
+:onError
+@echo An error occured!
+:onSuccess
+cd ..

--- a/examples/example2/build.sh
+++ b/examples/example2/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Copyright (c) 2012-2020 Sébastien Rombauts (sebastien.rombauts@gmail.com)
+#
+# Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
+# or copy at http://opensource.org/licenses/MIT)
+
+# exit on first error
+set -e
+
+mkdir -p build
+cd build
+
+# Generate a Makefile for GCC (or Clang, depanding on CC/CXX envvar)
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+
+# Build (ie 'make')
+cmake --build .
+

--- a/examples/example2/src/main.cpp
+++ b/examples/example2/src/main.cpp
@@ -1,0 +1,84 @@
+/**
+ * @file  main.cpp
+ * @brief A few short examples in a row.
+ *
+ *  Demonstrates how-to use the SQLite++ wrapper
+ *
+ * Copyright (c) 2012-2020 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ *
+ * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
+ * or copy at http://opensource.org/licenses/MIT)
+ */
+
+#include <iostream>
+#include <cstdio>
+#include <cstdlib>
+
+#include <SQLiteCpp/SQLiteCpp.h>
+
+
+#ifdef SQLITECPP_ENABLE_ASSERT_HANDLER
+namespace SQLite
+{
+/// definition of the assertion handler enabled when SQLITECPP_ENABLE_ASSERT_HANDLER is defined in the project (CMakeList.txt)
+void assertion_failed(const char* apFile, const long apLine, const char* apFunc, const char* apExpr, const char* apMsg)
+{
+    // Print a message to the standard error output stream, and abort the program.
+    std::cerr << apFile << ":" << apLine << ":" << " error: assertion failed (" << apExpr << ") in " << apFunc << "() with message \"" << apMsg << "\"\n";
+    std::abort();
+}
+}
+#endif
+
+int main ()
+{
+    // Using SQLITE_VERSION would require #include <sqlite3.h> which we want to avoid: use SQLite::VERSION if possible.
+//  std::cout << "SQlite3 version " << SQLITE_VERSION << std::endl;
+    std::cout << "SQlite3 version " << SQLite::VERSION << " (" << SQLite::getLibVersion() << ")" << std::endl;
+    std::cout << "SQliteC++ version " << SQLITECPP_VERSION << std::endl;
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Simple batch queries example :
+    try
+    {
+        // Open a database file in create/write mode
+        SQLite::Database    db("test.db3", SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
+        std::cout << "SQLite database file '" << db.getFilename().c_str() << "' opened successfully\n";
+
+        // Create a new table with an explicit "id" column aliasing the underlying rowid
+        db.exec("DROP TABLE IF EXISTS test");
+        db.exec("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)");
+
+        // first row
+        int nb = db.exec("INSERT INTO test VALUES (NULL, \"test\")");
+        std::cout << "INSERT INTO test VALUES (NULL, \"test\")\", returned " << nb << std::endl;
+
+        // second row
+        nb = db.exec("INSERT INTO test VALUES (NULL, \"second\")");
+        std::cout << "INSERT INTO test VALUES (NULL, \"second\")\", returned " << nb << std::endl;
+
+        // update the second row
+        nb = db.exec("UPDATE test SET value=\"second-updated\" WHERE id='2'");
+        std::cout << "UPDATE test SET value=\"second-updated\" WHERE id='2', returned " << nb << std::endl;
+
+        // Check the results : expect two row of result
+        SQLite::Statement   query(db, "SELECT * FROM test");
+        std::cout << "SELECT * FROM test :\n";
+        while (query.executeStep())
+        {
+            std::cout << "row (" << query.getColumn(0) << ", \"" << query.getColumn(1) << "\")\n";
+        }
+
+        db.exec("DROP TABLE test");
+    }
+    catch (std::exception& e)
+    {
+        std::cout << "SQLite exception: " << e.what() << std::endl;
+        return EXIT_FAILURE; // unexpected error : exit the example program
+    }
+    remove("test.db3");
+
+    std::cout << "everything ok, quitting\n";
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Demonstrates how to use SQLiteCpp as a subdirectory (out of tree) of a CMake project.

See https://github.com/SRombauts/SQLiteCpp_Example