### PR TITLE
CMakeLists.txt: Make c++11 optional unless building tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,13 @@ cmake_minimum_required(VERSION 3.1) # for "CMAKE_CXX_STANDARD" version
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake") # custom CMake modules like FindSQLiteCpp
 project(SQLiteCpp VERSION 2.99)
 
-# SQLiteC++ 3.x now requires C++11 compiler
-set(CMAKE_CXX_STANDARD 11)
+# SQLiteC++ 3.x requires C++11 features
+if (NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+elseif (CMAKE_CXX_STANDARD LESS 11)
+    message(WARNING "CMAKE_CXX_STANDARD has been set to '${CMAKE_CXX_STANDARD}' which is lower than the minimum required standard (c++11).")
+endif ()
+message(STATUS "Using c++ standard c++${CMAKE_CXX_STANDARD}")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 message (STATUS "CMake version: ${CMAKE_VERSION}")


### PR DESCRIPTION
Several minor changes with respect to c++ standard:
  * Changing `CMakeLists.txt` to make c++11 optional. This is a good idea because SQLiteCpp can support even older compilers. With this change, c++11 becomes requested but the build can proceed if it is not found.
  * When tests are enabled, c++11 becomes mandatory. The user is informed about this setting via cmake output.
  * Allow users to specify other c++ versions via the cmake options: `-DCMAKE_CXX_STANDARD="[98, 11, 14, 17, 20]"`

Its my understanding that this PR is more generic than https://github.com/SRombauts/SQLiteCpp/pull/239 because it allows users to manually specify a newer c++ standard, without all the special logic and extra options.

This PR may also supersede https://github.com/SRombauts/SQLiteCpp/pull/263 since it is more generic than the other PR.

Comments and feedback welcome.