### PR TITLE
Add missing Threads dependency to Config.cmake.in

### DIFF
--- a/cmake/SQLiteCppConfig.cmake.in
+++ b/cmake/SQLiteCppConfig.cmake.in
@@ -1,5 +1,9 @@
 include(CMakeFindDependencyMacro)
-find_dependency(SQLite3)
+find_dependency(SQLite3 REQUIRED)
+if(@UNIX@)
+    set(THREADS_PREFER_PTHREAD_FLAG @THREADS_PREFER_PTHREAD_FLAG@)
+    find_dependency(Threads REQUIRED)
+endif()
 
 @PACKAGE_INIT@
 


### PR DESCRIPTION
Without this, systems that linked against Threads::Threads (namely
Linux) don't "just work" with find_package(SQLiteCpp), but instead
require you to find & link against Threads manually.

So this fixes that by finiding it for you, if it was used.