### PR TITLE
Add SQLITE_OPEN_FULLMUTEX flag

### DIFF
--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -31,6 +31,7 @@ const int   OPEN_READONLY   = SQLITE_OPEN_READONLY;
 const int   OPEN_READWRITE  = SQLITE_OPEN_READWRITE;
 const int   OPEN_CREATE     = SQLITE_OPEN_CREATE;
 const int   OPEN_URI        = SQLITE_OPEN_URI;
+const int   OPEN_FULLMUTEX  = SQLITE_OPEN_FULLMUTEX;
 
 const int   OK              = SQLITE_OK;
 


### PR DESCRIPTION
Adressing https://github.com/SRombauts/SQLiteCpp/issues/282 to add missing SQLITE_OPEN_FULLMUTEX flag in SQLite namespace.