### PR TITLE
Add CMake option to toggle stack protection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,12 @@ else (MSVC)
     set(CPPLINT_ARG_OUTPUT      "--output=eclipse")
     set(CPPCHECK_ARG_TEMPLATE   "--template=gcc")
     # Useful compile flags and extra warnings
-    add_compile_options(-fstack-protector)
+    # Stack protection is not supported on MinGW-W64 on Windows, allow this flag to be turned off.
+    option(SQLITECPP_USE_STACK_PROTECTION "USE Stack Protection hardening." ON)
+    if (SQLITECPP_USE_STACK_PROTECTION)
+        message (STATUS "Using Stack Protection hardening")
+        add_compile_options(-fstack-protector)
+    endif()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wswitch-enum -Wshadow -Wno-long-long") # C++ only, don't bother with sqlite3
     if (CMAKE_COMPILER_IS_GNUCXX)
         # GCC flags


### PR DESCRIPTION
Using the MinGW-W64 compiler on Windows results in a segfault when a database is initially opened. This seems to be the result of the `-fstack-protector` flag, which has patchy support in MinGW. 

Note some other major projects that have encountered this, and don't add this flag when compiling with MinGW on Windows:
https://github.com/bitcoin/bitcoin/issues/8732
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86832

I can reproduce this with the example program and embedded sqlite3 library -- Building with MSVC works fine, and building with MinGW-W64 with the flag removed works fine, but segfaults at `sqlite3_open_v2()` with the flag added.

This PR adds a CMake option, `SQLITECPP_USE_STACK_PROTECTION`, defaulting to enabled, which allows disabling of this flag. Some other pull requests on this project to improve hardening (see #262) also mention this flag. In KOLANICH's PR, he excludes this flag unless the platform is Linux. I think that a good short-term solution short of refactoring all the hardening flags is to just keep this behind an option and document it with a comment in the CMakeFile.