### PR TITLE
Allow building of sqlite JSON1 extension when building internal sqlite library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,7 @@ endif ()
 option(SQLITECPP_INTERNAL_SQLITE "Add the internal SQLite3 source to the project." ON)
 if (SQLITECPP_INTERNAL_SQLITE)
     message(STATUS "Compile sqlite3 from source in subdirectory")
+    option(SQLITE_ENABLE_JSON1 "Enable JSON1 extension when building internal sqlite3 library." ON)
     # build the SQLite3 C library (for ease of use/compatibility) versus Linux sqlite3-dev package
     add_subdirectory(sqlite3)
     target_link_libraries(SQLiteCpp PUBLIC sqlite3)

--- a/sqlite3/CMakeLists.txt
+++ b/sqlite3/CMakeLists.txt
@@ -21,6 +21,12 @@ if (SQLITE_ENABLE_COLUMN_METADATA)
     target_compile_definitions(sqlite3 PUBLIC SQLITE_ENABLE_COLUMN_METADATA)
 endif (SQLITE_ENABLE_COLUMN_METADATA)
 
+if (SQLITE_ENABLE_JSON1)
+    # Enable JSON1 extension when building sqlite3
+    # See more here: https://www.sqlite.org/json1.html
+    target_compile_definitions(sqlite3 PUBLIC SQLITE_ENABLE_JSON1)
+endif (SQLITE_ENABLE_JSON1)
+
 if (UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))
     set_target_properties(sqlite3 PROPERTIES COMPILE_FLAGS "-fPIC")
 endif (UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))


### PR DESCRIPTION
I added cmake option to enable json1 extension when building internal sqlite library.
I added the option under the SQLITECPP_INTERNAL_SQLITE `if` statement so it is clear that this option is only valid when building the internal sqlite library.