### PR TITLE
Compile internal SQLite library with -ffunction-sections

### DIFF
--- a/sqlite3/CMakeLists.txt
+++ b/sqlite3/CMakeLists.txt
@@ -29,6 +29,11 @@ endif (SQLITE_ENABLE_JSON1)
 
 if (UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))
     set_target_properties(sqlite3 PROPERTIES COMPILE_FLAGS "-fPIC")
+
+    # Put each function in its own section to allow the linker garbage
+    # collection to remove unused section and produced a smaller
+    # statically-lined executables.
+    target_compile_options(sqlite3 PRIVATE "-ffunction-sections")
 endif (UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))
 
 if (UNIX AND CMAKE_COMPILER_IS_GNUCXX)


### PR DESCRIPTION
When building with SQLITECPP_INTERNAL_SQLITE=ON the SQLite amalgamation
source is used for generating the library. Using one big source file
means all the library code will be put in a single section. When
building statically linked executables the entire section will be
linked even if a small portion of the library is actually used.

This commit addresses this issue by setting the -ffunction-sections
compiler option when building the library. As each function is placed in
a section of its own the linker, when passed the --gc-sections, will
throw away unused sections (functions) and reduce the executable size.