### PR TITLE
Fix build warning due to string truncation

### DIFF
--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -310,7 +310,8 @@ Header Database::getHeaderInfo(const std::string& aFilename)
     }
 
     // If the "magic string" can't be found then header is invalid, corrupt or unreadable
-    strncpy(pHeaderStr, pBuf, 16);
+    memcpy(pHeaderStr, pBuf, 16);
+    pHeaderStr[15] = '\0';
     if (strncmp(pHeaderStr, "SQLite format 3", 15) != 0)
     {
         throw SQLite::Exception("Invalid or encrypted SQLite header in file " + aFilename);


### PR DESCRIPTION
strncpy gives an "output may be truncated" warning in newer versions of
GCC due to *pBuf being larger (100) than *pHeaderStr (16).  Use memcpy
and explicitly null-terminate the target string.

This fixes issue #306.