### PR TITLE
[CMake] Add SQLITECPP_INCLUDE_SCRIPT option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,24 +153,27 @@ set(SQLITECPP_DOC
 )
 source_group(doc FILES ${SQLITECPP_DOC})
 
-# list of config & script files of the library
-set(SQLITECPP_SCRIPT
- .editorconfig
- .gitbugtraq
- .github/workflows/build.yml
- .github/workflows/subdir_example.yml
- .gitignore
- .gitmodules
- .travis.yml
- appveyor.yml
- build.bat
- build.sh
- cpplint.py
- Doxyfile
- cmake/FindSQLite3.cmake
- cmake/SQLiteCppConfig.cmake.in
-)
-source_group(scripts FILES ${SQLITECPP_SCRIPT})
+option(SQLITECPP_INCLUDE_SCRIPT "Include config & script files." ON)
+if (SQLITECPP_INCLUDE_SCRIPT)
+    # list of config & script files of the library
+    set(SQLITECPP_SCRIPT
+     .editorconfig
+     .gitbugtraq
+     .github/workflows/build.yml
+     .github/workflows/subdir_example.yml
+     .gitignore
+     .gitmodules
+     .travis.yml
+     appveyor.yml
+     build.bat
+     build.sh
+     cpplint.py
+     Doxyfile
+     cmake/FindSQLite3.cmake
+     cmake/SQLiteCppConfig.cmake.in
+    )
+    source_group(scripts FILES ${SQLITECPP_SCRIPT})
+endif()
 
 # add sources of the wrapper as a "SQLiteCpp" static library
 add_library(SQLiteCpp ${SQLITECPP_SRC} ${SQLITECPP_INC} ${SQLITECPP_DOC} ${SQLITECPP_SCRIPT})


### PR DESCRIPTION
Add a `SQLITECPP_INCLUDE_SCRIPT` option to support disabling the addition of config & script files to the library.
(The default is `ON`, replicating current behavior.)

Adds flexibility without requiring library users to modify the `CMakeLists.txt` directly.
Also, this is needed for a dependent program that automatically packages the library source (as a dependency) in a source tarball "snapshot" and wants to exclude files not needed for building via CMake locally (.git* and such) to save space and reduce the overall file count.