### PR TITLE
Add Database constructor for filesystem::path #296

### DIFF
--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -12,7 +12,7 @@
 
 #include <SQLiteCpp/Column.h>
 
-#if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1911) ) // c++17: Visual Studio 2017 Update 3
+#if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1914) ) // c++17: Visual Studio 2017 version 15.7
 #include  <filesystem>
 #endif // c++17
 
@@ -155,7 +155,7 @@ public:
     {
     }
 
-    #if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1911) ) // c++17: Visual Studio 2017 Update 3
+    #if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1914) ) // c++17: Visual Studio 2017 version 15.7
     /**
      * @brief Open the provided database std::filesystem::path.
      *

--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -12,7 +12,7 @@
 
 #include <SQLiteCpp/Column.h>
 
-#if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) ) // c++17: Visual Studio 2017 Update 3
+#if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1911) ) // c++17: Visual Studio 2017 Update 3
 #include  <filesystem>
 #endif // c++17
 

--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -155,7 +155,7 @@ public:
     {
     }
 
-    #if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) ) // c++17: Visual Studio 2017 Update 3
+    #if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1911) ) // c++17: Visual Studio 2017 Update 3
     /**
      * @brief Open the provided database std::filesystem::path.
      *

--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -12,7 +12,7 @@
 
 #include <SQLiteCpp/Column.h>
 
-#if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1914) ) // c++17: Visual Studio 2017 version 15.7
+#if (__cplusplus >= 201703L) || ( defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L)) // c++17: Visual Studio 2017 version 15.7
 #include  <filesystem>
 #endif // c++17
 
@@ -155,11 +155,11 @@ public:
     {
     }
 
-    #if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1914) ) // c++17: Visual Studio 2017 version 15.7
+    #if (__cplusplus >= 201703L) || ( defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L)) // c++17: Visual Studio 2017 version 15.7
     /**
      * @brief Open the provided database std::filesystem::path.
      *
-     * This feature requires a c++17 capable compiler.
+     * @note This feature requires std=C++17
      * 
      * Uses sqlite3_open_v2() with readonly default flag, which is the opposite behavior
      * of the old sqlite3_open() function (READWRITE+CREATE).

--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -11,6 +11,11 @@
 #pragma once
 
 #include <SQLiteCpp/Column.h>
+
+#if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) ) // c++17: Visual Studio 2017 Update 3
+#include  <filesystem>
+#endif // c++17
+
 #include <memory>
 #include <string.h>
 
@@ -149,6 +154,36 @@ public:
         Database(aFilename.c_str(), aFlags, aBusyTimeoutMs, aVfs.empty() ? nullptr : aVfs.c_str())
     {
     }
+
+    #if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) ) // c++17: Visual Studio 2017 Update 3
+    /**
+     * @brief Open the provided database std::filesystem::path.
+     *
+     * This feature requires a c++17 capable compiler.
+     * 
+     * Uses sqlite3_open_v2() with readonly default flag, which is the opposite behavior
+     * of the old sqlite3_open() function (READWRITE+CREATE).
+     * This makes sense if you want to use it on a readonly filesystem
+     * or to prevent creation of a void file when a required file is missing.
+     *
+     * Exception is thrown in case of error, then the Database object is NOT constructed.
+     *
+     * @param[in] apFilename        Path/uri to the database file ("filename" sqlite3 parameter)
+     * @param[in] aFlags            SQLite::OPEN_READONLY/SQLite::OPEN_READWRITE/SQLite::OPEN_CREATE...
+     * @param[in] aBusyTimeoutMs    Amount of milliseconds to wait before returning SQLITE_BUSY (see setBusyTimeout())
+     * @param[in] apVfs             UTF-8 name of custom VFS to use, or nullptr for sqlite3 default
+     *
+     * @throw SQLite::Exception in case of error
+     */
+    Database(const std::filesystem::path& apFilename,
+             const int   aFlags         = SQLite::OPEN_READONLY,
+             const int   aBusyTimeoutMs = 0,
+             const std::string& aVfs            = "") :
+        Database(apFilename.c_str(), aFlags, aBusyTimeoutMs, aVfs.empty() ? nullptr : aVfs.c_str())
+    {
+    }
+
+    #endif // c++17
 
     // Database is non-copyable
     Database(const Database&) = delete;

--- a/tests/Database_test.cpp
+++ b/tests/Database_test.cpp
@@ -15,6 +15,10 @@
 
 #include <gtest/gtest.h>
 
+#if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) ) // c++17: Visual Studio 2017 Update 3
+#include  <filesystem>
+#endif // c++17
+
 #include <cstdio>
 #include <fstream>
 
@@ -46,8 +50,13 @@ TEST(Database, ctorExecCreateDropExist)
         std::string filename = "test.db3";
         EXPECT_THROW(SQLite::Database not_found(filename), SQLite::Exception);
 
-        // Create a new database
-        SQLite::Database db("test.db3", SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
+        // Create a new database using a string or a std::filesystem::path if using c++17
+        #if (__cplusplus < 201703L) || ( defined(_MSC_VER) && (_MSC_VER < 1911) ) // c++17: Visual Studio 2017 Update 3
+            SQLite::Database db("test.db3", SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
+        #else
+            SQLite::Database db(std::filesystem::path("test.db3"), SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
+        #endif
+
         EXPECT_STREQ("test.db3", db.getFilename().c_str());
         EXPECT_FALSE(db.tableExists("test"));
         EXPECT_FALSE(db.tableExists(std::string("test")));

--- a/tests/Database_test.cpp
+++ b/tests/Database_test.cpp
@@ -15,7 +15,7 @@
 
 #include <gtest/gtest.h>
 
-#if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1914) ) // c++17: Visual Studio 2017 version 15.7
+#if (__cplusplus >= 201703L) || ( defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L)) // c++17: Visual Studio 2017 version 15.7
 #include  <filesystem>
 #endif // c++17
 
@@ -51,10 +51,10 @@ TEST(Database, ctorExecCreateDropExist)
         EXPECT_THROW(SQLite::Database not_found(filename), SQLite::Exception);
 
         // Create a new database using a string or a std::filesystem::path if using c++17
-        #if (__cplusplus < 201703L) || ( defined(_MSC_VER) && (_MSC_VER < 1914) ) // c++17: Visual Studio 2017 version 15.7
-            SQLite::Database db("test.db3", SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
-        #else
+        #if (__cplusplus >= 201703L) || ( defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L)) // c++17: Visual Studio 2017 version 15.7
             SQLite::Database db(std::filesystem::path("test.db3"), SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
+        #else
+            SQLite::Database db("test.db3", SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
         #endif // c++17
 
         EXPECT_STREQ("test.db3", db.getFilename().c_str());

--- a/tests/Database_test.cpp
+++ b/tests/Database_test.cpp
@@ -15,7 +15,7 @@
 
 #include <gtest/gtest.h>
 
-#if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) ) // c++17: Visual Studio 2017 Update 3
+#if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1911) ) // c++17: Visual Studio 2017 Update 3
 #include  <filesystem>
 #endif // c++17
 

--- a/tests/Database_test.cpp
+++ b/tests/Database_test.cpp
@@ -15,7 +15,7 @@
 
 #include <gtest/gtest.h>
 
-#if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1911) ) // c++17: Visual Studio 2017 Update 3
+#if (__cplusplus >= 201703L) || ( defined(_MSC_VER) && (_MSC_VER >= 1914) ) // c++17: Visual Studio 2017 version 15.7
 #include  <filesystem>
 #endif // c++17
 
@@ -51,11 +51,11 @@ TEST(Database, ctorExecCreateDropExist)
         EXPECT_THROW(SQLite::Database not_found(filename), SQLite::Exception);
 
         // Create a new database using a string or a std::filesystem::path if using c++17
-        #if (__cplusplus < 201703L) || ( defined(_MSC_VER) && (_MSC_VER < 1911) ) // c++17: Visual Studio 2017 Update 3
+        #if (__cplusplus < 201703L) || ( defined(_MSC_VER) && (_MSC_VER < 1914) ) // c++17: Visual Studio 2017 version 15.7
             SQLite::Database db("test.db3", SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
         #else
             SQLite::Database db(std::filesystem::path("test.db3"), SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
-        #endif
+        #endif // c++17
 
         EXPECT_STREQ("test.db3", db.getFilename().c_str());
         EXPECT_FALSE(db.tableExists("test"));


### PR DESCRIPTION
Added an additional constructor in `Database.h` that accepts a `std::filesystem::path` object. Also updated the `ctorExecCreateDropExist` unit test in `Database_test.h` which will test the new constructor if the detected compiler supports c++17.  