### PR TITLE
Fix std::filesystem::path Database constructor (fixes #317)

### DIFF
--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -179,7 +179,8 @@ public:
              const int   aFlags         = SQLite::OPEN_READONLY,
              const int   aBusyTimeoutMs = 0,
              const std::string& aVfs            = "") :
-        Database(apFilename.c_str(), aFlags, aBusyTimeoutMs, aVfs.empty() ? nullptr : aVfs.c_str())
+        Database(reinterpret_cast<const char*>(apFilename.u8string().c_str()),
+                 aFlags, aBusyTimeoutMs, aVfs.empty() ? nullptr : aVfs.c_str())
     {
     }
 


### PR DESCRIPTION
The return type of `path.c_str()` is platform-dependent and is a `wstring` on windows. `path.u8string()` always returns an utf8-encoded string.

In c++17, that string has type `std::string`, but starting in c++20 it is `std::u8string`. I used a reinterpret_cast to handle the c++20 case.

Alternatively, a constructor taking u8string could be added for the c++20 case. But it seems odd to have only one place where the library accepts u8strings. If support for u8strings is added, it should probably be done for the whole library at once.