### PR TITLE
Fix Readme installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,6 @@ Example for Linux:
 ```cmake
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/thirdparty/SQLiteCpp)
 
-include_directories(
-  ${CMAKE_CURRENT_LIST_DIR}/thirdparty/SQLiteCpp/include
-)
-
 add_executable(main src/main.cpp)
 target_link_libraries(main
   SQLiteCpp


### PR DESCRIPTION
Removes manually adding the include directory from the Readme install instructions.
The manual step is not needed since the include dir is already added on the library target by the current CMake configuration: https://github.com/SRombauts/SQLiteCpp/blob/f6b32259f2d3733b645049b015152322ba4c2694/CMakeLists.txt#L299
