### PR TITLE
Disable std::filesystem on macOS when compiling C++17 but targetting <10.15

### DIFF
--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -14,9 +14,24 @@
 
 // c++17: MinGW GCC version > 8
 // c++17: Visual Studio 2017 version 15.7
-#if ((__cplusplus >= 201703L) && ((!defined(__MINGW32__) && !defined(__MINGW64__)) || (__GNUC__ > 8))) || (defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L)) // NOLINT
+// c++17: macOS unless targetting compatibility with macOS < 10.15
+#if __cplusplus >= 201703L
+    #if defined(__MINGW32__) || defined(__MINGW64__)
+        #if __GNUC__ > 8 // MinGW requires GCC version > 8 for std::filesystem
+            #define SQLITECPP_HAVE_STD_FILESYSTEM
+        #endif
+    #elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < 101500
+        // macOS clang won't less us touch std::filesystem if we're targetting earlier than 10.15
+    #else
+        #define SQLITECPP_HAVE_STD_FILESYSTEM
+    #endif
+#elif defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
+    #define SQLITECPP_HAVE_STD_FILESYSTEM
+#endif
+
+#ifdef SQLITECPP_HAVE_STD_FILESYSTEM
 #include  <filesystem>
-#endif // c++17
+#endif // c++17 and a suitable compiler
 
 #include <memory>
 #include <string.h>
@@ -167,9 +182,7 @@ public:
     {
     }
 
-    // c++17: MinGW GCC version > 8
-    // c++17: Visual Studio 2017 version 15.7
-    #if ((__cplusplus >= 201703L) && ((!defined(__MINGW32__) && !defined(__MINGW64__)) || (__GNUC__ > 8))) || (defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L)) // NOLINT
+    #ifdef SQLITECPP_HAVE_STD_FILESYSTEM
 
     /**
      * @brief Open the provided database std::filesystem::path.
@@ -199,7 +212,7 @@ public:
     {
     }
 
-    #endif // c++17
+    #endif // have std::filesystem
 
     // Database is non-copyable
     Database(const Database&) = delete;

--- a/tests/Database_test.cpp
+++ b/tests/Database_test.cpp
@@ -15,7 +15,7 @@
 
 #include <gtest/gtest.h>
 
-#if (__cplusplus >= 201703L) || ( defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L)) // c++17: Visual Studio 2017 version 15.7
+#ifdef SQLITECPP_HAVE_STD_FILESYSTEM
 #include  <filesystem>
 #endif // c++17
 
@@ -50,12 +50,13 @@ TEST(Database, ctorExecCreateDropExist)
         std::string filename = "test.db3";
         EXPECT_THROW(SQLite::Database not_found(filename), SQLite::Exception);
 
-        // Create a new database using a string or a std::filesystem::path if using c++17
-        #if (__cplusplus >= 201703L) || ( defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L)) // c++17: Visual Studio 2017 version 15.7
+        // Create a new database using a string or a std::filesystem::path if using c++17 and a
+        // compatible compiler
+        #ifdef SQLITECPP_HAVE_STD_FILESYSTEM
             SQLite::Database db(std::filesystem::path("test.db3"), SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
         #else
             SQLite::Database db("test.db3", SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
-        #endif // c++17
+        #endif // have std::filesystem
 
         EXPECT_STREQ("test.db3", db.getFilename().c_str());
         EXPECT_FALSE(db.tableExists("test"));


### PR DESCRIPTION
macOS flat out refuses to compile if you touch `std::filesystem::path` when targetting macOS < 10.15 (to be able to deploy a binary to older macOS versions) with the `-mmacosx-version-min=10.14` (or earlier) compiler flags.

If you try to compile code with `::path` (even if you don't actually call it) the Apple clang gods smite you with:
```
foo.cpp:8:26: error: 'path' is unavailable: introduced in macOS 10.15
        std::filesystem::path p;
                         ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/filesystem:738:24: note: 'path' has been explicitly marked unavailable here
class _LIBCPP_TYPE_VIS path {
                       ^
```

This is reportedly caused by Apple's C++ team being somewhat incompetent at actually updating libc++ when they push out new releases, so libc++ stl features (in this case, to get at the std::filesystem exceptions from libc++) often lag behind the compiler by years, and Apple never releases libc++ updates for older mac versions because they don't care because C++ isn't Swift and only Swift is great and good.

\</rant\>

*Anyway*, this PR works around the issue by disabling the std::filesystem::path support when in C++17 mode when targetting macOS before 10.15.

I also broke up the hairy macro conditions because it was already hard to follow and would have gotten worse if kept in a single condition.