### PR TITLE
Added std::vector version of getColumns()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ example1
 *.a
 
 .vscode/
+.vs/
 /SQLiteCpp.sln
 *.ncb
 *.suo

--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -621,7 +621,7 @@ public:
      * @brief Return an instance of T constructed from copies of the first N columns
      *
      *  Can be used to access the data of the current row of result when applicable,
-     * while the executeStep() method returns true.
+     *  while the executeStep() method returns true.
      *
      *  Throw an exception if there is no row to return a Column from:
      * - if provided column count is out of bound
@@ -638,6 +638,30 @@ public:
      */
     template<typename T, int N>
     T       getColumns();
+
+    /**
+     * @brief Return an std::array of Column objects of the first N columns
+     *
+     *  Can be used to access the data of the current row of result when applicable,
+     *  while the executeStep() method returns true.
+     *
+     *  Throw an exception if there is no row to return a Column from:
+     * - if provided column count is out of bound
+     * - before any executeStep() call
+     * - after the last executeStep() returned false
+     * - after a reset() call
+     *
+     *  Throw an exception if the specified column count is out of the [0, getColumnCount()) range.
+     *
+     * @tparam  N   Number of columns
+     *
+     * @note Requires std=C++14
+     */
+    template<int N>
+    std::array<SQLite::Column, N>  getColumns()
+    {
+        return getColumns<std::array<SQLite::Column, N>, N>();
+    }
 
 private:
     /**

--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -14,6 +14,7 @@
 #include <SQLiteCpp/Utils.h> // SQLITECPP_PURE_FUNC
 
 #include <string>
+#include <vector>
 #include <map>
 #include <climits> // For INT_MAX
 
@@ -551,6 +552,69 @@ public:
      *  Throw an exception if the specified name is not one of the aliased name of the columns in the result.
      */
     Column  getColumn(const char* apName);
+
+    /**
+     * @brief Return a vector of the single row columns objects
+     *
+     *  Can be used to access the data of the current row of result when applicable,
+     * while the executeStep() method returns true.
+     *
+     *  Throw an exception if there is no row to return a Column from :
+     * - if provided index is out of bound
+     * - before any executeStep() call
+     * - after the last executeStep() returned false
+     * - after a reset() call
+     *
+     *  Throw an exception if the specified column count is out of the [0, getColumnCount()) range.
+     *
+     * @param[in] aNumber   Number of the first columns to get (leave as 0 to get all columns)
+     *
+     * @note    Creates an instance of std::vector. You should prefer invoking getColumns with a reference
+     *          to existing std::vector<SQLite::Columns> when you invoke this method more than once 
+     *          for statement to avoid unnecessary allocations.
+     *
+     * @note    This method is not const, reflecting the fact that the returned Column object will
+     *          share the ownership of the underlying sqlite3_stmt.
+     *
+     * @warning The resulting Column object must not be memorized "as-is".
+     *          Is is only a wrapper around the current result row, so it is only valid
+     *          while the row from the Statement remains valid, that is only until next executeStep() call.
+     *          Thus, you should instead extract immediately its data (getInt(), getText()...)
+     *          and use or copy this data for any later usage.
+     */
+    std::vector<Column> getColumns(const int aNumber = 0);
+
+    /**
+     * @brief Return and fills the given vector of the single row columns objects
+     *
+     *  Can be used to access the data of the current row of result when applicable,
+     * while the executeStep() method returns true.
+     *
+     *  Throw an exception if there is no row to return a Column from :
+     * - if provided index is out of bound
+     * - before any executeStep() call
+     * - after the last executeStep() returned false
+     * - after a reset() call
+     *
+     *  Throw an exception if the specified column count is out of the [0, getColumnCount()) range.
+     *
+     * @param[in] arBuffer  Reference to std::vector<SQLite::Columns> to be cleared and filled with columns
+     * @param[in] aNumber   Number of the first columns to get (leave as 0 to get all columns)
+     *
+     * @note    This metod is using an exisitng of std::vector. You can use getColumns without this reference
+     *          for simple uses cases or to get the instance of std::vector<SQLite::Columns> to use
+     *          with this method.
+     *
+     * @note    This method is not const, reflecting the fact that the returned Column object will
+     *          share the ownership of the underlying sqlite3_stmt.
+     *
+     * @warning The resulting Column object must not be memorized "as-is".
+     *          Is is only a wrapper around the current result row, so it is only valid
+     *          while the row from the Statement remains valid, that is only until next executeStep() call.
+     *          Thus, you should instead extract immediately its data (getInt(), getText()...)
+     *          and use or copy this data for any later usage.
+     */
+    std::vector<Column>& getColumns(std::vector<Column>& arBuffer, const int aNumber = 0);
 
 #if __cplusplus >= 201402L || (defined(_MSC_VER) && _MSC_VER >= 1900) // c++14: Visual Studio 2015
      /**

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -347,6 +347,35 @@ std::string Statement::getExpandedSQL() {
     return expandedString;
 }
 
+// Return a std::vector of the columns data with an option to limit result to specified number of the first columns
+// (use the Column copy-constructor)
+std::vector<Column> Statement::getColumns(const int aNumber)
+{
+    checkRow();
+    std::vector<Column> row;
+    getColumns(row, aNumber);
+    return row;
+}
+
+// Return a reference to given std::vector filled with columns with an option to limit result to specified number of the first columns
+// (use the Column copy-constructor)
+std::vector<Column>& Statement::getColumns(std::vector<Column>& arBuffer, const int aNumber)
+{
+    checkRow();
+    int columns_amount = aNumber;
+    if (columns_amount <= 0) {
+        columns_amount = mColumnCount;
+    }
+    checkIndex(columns_amount - 1);
+
+    arBuffer.clear();
+    arBuffer.reserve(columns_amount);
+    for (int i = 0; i < columns_amount; ++i) {
+        arBuffer.emplace_back(mStmtPtr, i);
+    }
+    return arBuffer;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Internal class : shared pointer to the sqlite3_stmt SQLite Statement Object
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/Statement_test.cpp
+++ b/tests/Statement_test.cpp
@@ -18,6 +18,7 @@
 
 #include <cstdio>
 #include <stdint.h>
+#include <array>
 
 #include <climits> // For INT_MAX
 
@@ -1062,6 +1063,12 @@ TEST(Statement, getColumnsTemplate)
     EXPECT_EQ("first", testStruct2.msg);
     EXPECT_EQ(-1, testStruct2.integer);
     EXPECT_EQ(0.0, testStruct2.real);
+    
+    // Get std::array of only the first 2 columns
+    auto testArray = query.getColumns<2>();
+    EXPECT_EQ(1, testArray[0].getInt());
+    EXPECT_EQ("first", testArray[1].getString());
+    EXPECT_EQ(2, testArray.size());
 }
 #endif
 


### PR DESCRIPTION
I created a new variants of Statement::getColumns to retrive all columns objects of single row using one command:
- std::vector<Column> getColumns(const int aNumber = 0)
- std::vector<Column>& getColumns(std::vector<Column>& arBuffer, const int aNumber = 0)
- std::array<SQLite::Column, N> getColumns()
First two methods use std::vector to get whole row, when we don't know number of columns in compile time
or want to use a non const variable to retrieve columns.
Second method allows us to reuse std::vector, so we can allocate memory only once.
Third method is useful when we know number of columns in compile time and it is just an alias of
T getColumns(T, N).

This changes could simplify user codes, for examples:
- Retrieving information about columns in table
```cpp
SQLite::Statement q(...);
q.executeStep();
std::cout << "Columns: \n";
for ( const auto& column : q.getColumns() ) {
    std::cout << "Name: " << column.getName() << "\t Type: " << column.getType() << '\n';
}
```
- Processing whole table/query in range-based for loop
```cpp
SQLite::Statement q(...);
std::vector<SQLite::Column> row;
while( q.executeStep() ) {
    for ( const auto& column : q.getColumns(row) ) {
        std::cout << column.getText() << '\t';
    }
    std::cout << '\n';
}
```
- Deserializing big classes without using separate struct
```cpp
SQLite::Statement& operator<< (MyClass& c, SQLite::Statement& s)
{
    auto columns = s.getColumns<2>();
    c.m1 = columns[0].getUInt();
    c.m2 = columns[1].getText();
    return s;
}
```

I also made a test for this methods and renamed previous "getColumns" test to "getColumnsTemplate"
