### PR TITLE
Refactoring of Statement and Column classes

### DIFF
--- a/include/SQLiteCpp/Column.h
+++ b/include/SQLiteCpp/Column.h
@@ -54,7 +54,7 @@ public:
      * @param[in] aStmtPtr  Shared pointer to the prepared SQLite Statement Object.
      * @param[in] aIndex    Index of the column in the row of result, starting at 0
      */
-    Column(Statement::TStatementPtr& aStmtPtr, int aIndex) noexcept;
+    explicit Column(Statement::TStatementPtr& aStmtPtr, int aIndex) noexcept;
 
     // default destructor: the finalization will be done by the destructor of the last shared pointer
     // default copy constructor and assignment operator are perfectly suited :
@@ -246,7 +246,7 @@ public:
      *
      * @see getString
      */
-    operator std::string() const
+    explicit operator std::string() const
     {
         return getString();
     }

--- a/include/SQLiteCpp/Column.h
+++ b/include/SQLiteCpp/Column.h
@@ -54,7 +54,7 @@ public:
      * @param[in] aStmtPtr  Shared pointer to the prepared SQLite Statement Object.
      * @param[in] aIndex    Index of the column in the row of result, starting at 0
      */
-    explicit Column(const Statement::TStatementPtr& aStmtPtr, int aIndex) noexcept;
+    explicit Column(const Statement::TStatementPtr& aStmtPtr, int aIndex);
 
     // default destructor: the finalization will be done by the destructor of the last shared pointer
     // default copy constructor and assignment operator are perfectly suited :

--- a/include/SQLiteCpp/Column.h
+++ b/include/SQLiteCpp/Column.h
@@ -246,7 +246,7 @@ public:
      *
      * @see getString
      */
-    explicit operator std::string() const
+    operator std::string() const
     {
         return getString();
     }

--- a/include/SQLiteCpp/Column.h
+++ b/include/SQLiteCpp/Column.h
@@ -14,8 +14,11 @@
 #include <SQLiteCpp/Exception.h>
 
 #include <string>
+#include <memory>
 #include <climits> // For INT_MAX
 
+// Forward declarations to avoid inclusion of <sqlite3.h> in a header
+struct sqlite3_stmt;
 
 namespace SQLite
 {
@@ -25,7 +28,6 @@ extern const int FLOAT;     ///< SQLITE_FLOAT
 extern const int TEXT;      ///< SQLITE_TEXT
 extern const int BLOB;      ///< SQLITE_BLOB
 extern const int Null;      ///< SQLITE_NULL
-
 
 /**
  * @brief Encapsulation of a Column in a row of the result pointed by the prepared Statement.
@@ -52,7 +54,7 @@ public:
      * @param[in] aStmtPtr  Shared pointer to the prepared SQLite Statement Object.
      * @param[in] aIndex    Index of the column in the row of result, starting at 0
      */
-    Column(Statement::Ptr& aStmtPtr, int aIndex) noexcept;
+    Column(Statement::TStatementPtr& aStmtPtr, int aIndex) noexcept;
 
     // default destructor: the finalization will be done by the destructor of the last shared pointer
     // default copy constructor and assignment operator are perfectly suited :
@@ -250,8 +252,8 @@ public:
     }
 
 private:
-    Statement::Ptr  mStmtPtr;   ///< Shared Pointer to the prepared SQLite Statement Object
-    int             mIndex;     ///< Index of the column in the row of result, starting at 0
+    Statement::TStatementPtr    mStmtPtr;  ///< Shared Pointer to the prepared SQLite Statement Object
+    int                         mIndex;    ///< Index of the column in the row of result, starting at 0
 };
 
 /**
@@ -281,7 +283,7 @@ T Statement::getColumns()
 template<typename T, const int... Is>
 T Statement::getColumns(const std::integer_sequence<int, Is...>)
 {
-    return T{Column(mStmtPtr, Is)...};
+    return T{Column(mpPreparedStatement, Is)...};
 }
 
 #endif

--- a/include/SQLiteCpp/Column.h
+++ b/include/SQLiteCpp/Column.h
@@ -54,7 +54,7 @@ public:
      * @param[in] aStmtPtr  Shared pointer to the prepared SQLite Statement Object.
      * @param[in] aIndex    Index of the column in the row of result, starting at 0
      */
-    explicit Column(Statement::TStatementPtr& aStmtPtr, int aIndex) noexcept;
+    explicit Column(const Statement::TStatementPtr& aStmtPtr, int aIndex) noexcept;
 
     // default destructor: the finalization will be done by the destructor of the last shared pointer
     // default copy constructor and assignment operator are perfectly suited :

--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -699,17 +699,15 @@ private:
      */
     sqlite3_stmt* getPreparedStatement() const;
 
-
-    /// Map of columns index by name (mutable so getColumnIndex can be const)
-    using TColumnNames = std::map<std::string, int>;
-
     std::string             mQuery;                 //!< UTF-8 SQL Query
     sqlite3*                mpSQLite;               //!< Pointer to SQLite Database Connection Handle
     TStatementPtr           mpPreparedStatement;    //!< Shared Pointer to the prepared SQLite Statement Object
     int                     mColumnCount{0};        //!< Number of columns in the result of the prepared statement
-    mutable TColumnNames    mColumnNames;           //!< Map of columns index by name (mutable so getColumnIndex can be const)
     bool                    mbHasRow{false};        //!< true when a row has been fetched with executeStep()
     bool                    mbDone{false};          //!< true when the last executeStep() had no more row to fetch
+    
+    /// Map of columns index by name (mutable so getColumnIndex can be const)
+    mutable std::map<std::string, int>  mColumnNames{};
 };
 
 

--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -79,7 +79,7 @@ public:
      *
      * @param[in] aStatement    Statement to move
      */
-    Statement(Statement&& aStatement) noexcept = default;
+    Statement(Statement&& aStatement) noexcept;
     Statement& operator=(Statement&& aStatement) noexcept = default;
 
     // Statement is non-copyable

--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -60,7 +60,7 @@ public:
      *
      * Exception is thrown in case of error, then the Statement object is NOT constructed.
      */
-    Statement(Database& aDatabase, const char* apQuery);
+    Statement(const Database& aDatabase, const char* apQuery);
 
     /**
      * @brief Compile and register the SQL query for the provided SQLite Database Connection
@@ -70,7 +70,7 @@ public:
      *
      * Exception is thrown in case of error, then the Statement object is NOT constructed.
      */
-    Statement(Database &aDatabase, const std::string& aQuery) :
+    Statement(const Database& aDatabase, const std::string& aQuery) :
         Statement(aDatabase, aQuery.c_str())
     {}
 
@@ -122,7 +122,7 @@ public:
     // => if you know what you are doing, use bindNoCopy() instead of bind()
 
     SQLITECPP_PURE_FUNC
-    int getIndex(const char * const apName);
+    int getIndex(const char * const apName) const;
 
     /**
      * @brief Bind an int value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
@@ -463,7 +463,7 @@ public:
      *          Thus, you should instead extract immediately its data (getInt(), getText()...)
      *          and use or copy this data for any later usage.
      */
-    Column  getColumn(const int aIndex);
+    Column  getColumn(const int aIndex) const;
 
     /**
      * @brief Return a copy of the column data specified by its column name (less efficient than using an index)
@@ -494,7 +494,7 @@ public:
      *
      *  Throw an exception if the specified name is not one of the aliased name of the columns in the result.
      */
-    Column  getColumn(const char* apName);
+    Column  getColumn(const char* apName) const;
 
 #if __cplusplus >= 201402L || (defined(_MSC_VER) && _MSC_VER >= 1900) // c++14: Visual Studio 2015
      /**
@@ -617,7 +617,7 @@ public:
     }
 
     // Return a UTF-8 string containing the SQL text of prepared statement with bound parameters expanded.
-    std::string getExpandedSQL();
+    std::string getExpandedSQL() const;
 
     /// Return the number of columns in the result set returned by the prepared statement
     int getColumnCount() const
@@ -646,7 +646,7 @@ public:
     const char* getErrorMsg() const noexcept;
 
     /// Shared pointer to SQLite Prepared Statement Object
-    typedef std::shared_ptr<sqlite3_stmt> TStatementPtr;
+    using TStatementPtr = std::shared_ptr<sqlite3_stmt>;
 
 private:
     /**
@@ -699,11 +699,10 @@ private:
      */
     sqlite3_stmt* getPreparedStatement() const;
 
-private:
-    /// Map of columns index by name (mutable so getColumnIndex can be const)
-    typedef std::map<std::string, int> TColumnNames;
 
-private:
+    /// Map of columns index by name (mutable so getColumnIndex can be const)
+    using TColumnNames = std::map<std::string, int>;
+
     std::string             mQuery;                 //!< UTF-8 SQL Query
     sqlite3*                mpSQLite;               //!< Pointer to SQLite Database Connection Handle
     TStatementPtr           mpPreparedStatement;    //!< Shared Pointer to the prepared SQLite Statement Object

--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -79,7 +79,8 @@ public:
      *
      * @param[in] aStatement    Statement to move
      */
-    Statement(Statement&& aStatement) noexcept;
+    Statement(Statement&& aStatement) noexcept = default;
+    Statement& operator=(Statement&& aStatement) noexcept = default;
 
     // Statement is non-copyable
     Statement(const Statement&) = delete;

--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -15,7 +15,6 @@
 
 #include <string>
 #include <map>
-#include <climits> // For INT_MAX
 
 // Forward declarations to avoid inclusion of <sqlite3.h> in a header
 struct sqlite3;
@@ -128,34 +127,15 @@ public:
     /**
      * @brief Bind an int value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const int aIndex, const int           aValue);
+    void bind(const int aIndex, const int32_t       aValue);
     /**
      * @brief Bind a 32bits unsigned int value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const int aIndex, const unsigned      aValue);
-
-#if (LONG_MAX == INT_MAX) // 4 bytes "long" type means the data model is ILP32 or LLP64 (Win64 Visual C++ and MinGW)
-    /**
-     * @brief Bind a 32bits long value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
-     */
-    void bind(const int aIndex, const long          aValue)
-    {
-        bind(aIndex, static_cast<int>(aValue));
-    }
-#else // 8 bytes "long" type means the data model is LP64 (Most Unix-like, Windows when using Cygwin; z/OS)
-    /**
-     * @brief Bind a 64bits long value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
-     */
-    void bind(const int aIndex, const long          aValue)
-    {
-        bind(aIndex, static_cast<long long>(aValue));
-    }
-#endif
-
+    void bind(const int aIndex, const uint32_t      aValue);
     /**
      * @brief Bind a 64bits int value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const int aIndex, const long long     aValue);
+    void bind(const int aIndex, const int64_t       aValue);
     /**
      * @brief Bind a double (64bits float) value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
@@ -210,39 +190,21 @@ public:
     /**
      * @brief Bind an int value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const char* apName, const int             aValue)
+    void bind(const char* apName, const int32_t         aValue)
     {
         bind(getIndex(apName), aValue);
     }
     /**
      * @brief Bind a 32bits unsigned int value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const char* apName, const unsigned        aValue)
+    void bind(const char* apName, const uint32_t        aValue)
     {
         bind(getIndex(apName), aValue);
     }
-
-#if (LONG_MAX == INT_MAX) // 4 bytes "long" type means the data model is ILP32 or LLP64 (Win64 Visual C++ and MinGW)
-    /**
-     * @brief Bind a 32bits long value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
-     */
-    void bind(const char* apName, const long           aValue)
-    {
-        bind(apName, static_cast<int>(aValue));
-    }
-#else // 8 bytes "long" type means the data model is LP64 (Most Unix-like, Windows when using Cygwin; z/OS)
-    /**
-     * @brief Bind a 64bits long value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
-     */
-    void bind(const char* apName, const long           aValue)
-    {
-        bind(apName, static_cast<long long>(aValue));
-    }
-#endif
     /**
      * @brief Bind a 64bits int value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const char* apName, const long long       aValue)
+    void bind(const char* apName, const int64_t         aValue)
     {
         bind(getIndex(apName), aValue);
     }
@@ -325,46 +287,28 @@ public:
     /**
      * @brief Bind an int value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const std::string& aName, const int            aValue)
+    void bind(const std::string& aName, const int32_t         aValue)
     {
         bind(aName.c_str(), aValue);
     }
     /**
      * @brief Bind a 32bits unsigned int value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const std::string& aName, const unsigned       aValue)
+    void bind(const std::string& aName, const uint32_t        aValue)
     {
         bind(aName.c_str(), aValue);
     }
-
-#if (LONG_MAX == INT_MAX) // 4 bytes "long" type means the data model is ILP32 or LLP64 (Win64 Visual C++ and MinGW)
-    /**
-     * @brief Bind a 32bits long value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
-     */
-    void bind(const std::string& aName, const long                  aValue)
-    {
-        bind(aName.c_str(), static_cast<int>(aValue));
-    }
-#else // 8 bytes "long" type means the data model is LP64 (Most Unix-like, Windows when using Cygwin; z/OS)
-    /**
-     * @brief Bind a 64bits long value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
-     */
-    void bind(const std::string& aName, const long                   aValue)
-    {
-        bind(aName.c_str(), static_cast<long long>(aValue));
-    }
-#endif
     /**
      * @brief Bind a 64bits int value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const std::string& aName, const long long      aValue)
+    void bind(const std::string& aName, const int64_t         aValue)
     {
         bind(aName.c_str(), aValue);
     }
     /**
      * @brief Bind a double (64bits float) value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const std::string& aName, const double         aValue)
+    void bind(const std::string& aName, const double          aValue)
     {
         bind(aName.c_str(), aValue);
     }

--- a/src/Column.cpp
+++ b/src/Column.cpp
@@ -30,6 +30,10 @@ Column::Column(const Statement::TStatementPtr& aStmtPtr, int aIndex) noexcept :
     mStmtPtr(aStmtPtr),
     mIndex(aIndex)
 {
+    if (!aStmtPtr)
+    {
+        throw SQLite::Exception("Statement was destroyed");
+    }
 }
 
 // Return the named assigned to this result column (potentially aliased)

--- a/src/Column.cpp
+++ b/src/Column.cpp
@@ -26,7 +26,7 @@ const int Null      = SQLITE_NULL;
 
 
 // Encapsulation of a Column in a row of the result pointed by the prepared Statement.
-Column::Column(Statement::TStatementPtr& aStmtPtr, int aIndex) noexcept :
+Column::Column(const Statement::TStatementPtr& aStmtPtr, int aIndex) noexcept :
     mStmtPtr(aStmtPtr),
     mIndex(aIndex)
 {
@@ -73,7 +73,7 @@ double Column::getDouble() const noexcept
 // Return a pointer to the text value (NULL terminated string) of the column specified by its index starting at 0
 const char* Column::getText(const char* apDefaultValue /* = "" */) const noexcept
 {
-    const char* pText = reinterpret_cast<const char*>(sqlite3_column_text(mStmtPtr.get(), mIndex));
+    auto pText = reinterpret_cast<const char*>(sqlite3_column_text(mStmtPtr.get(), mIndex));
     return (pText?pText:apDefaultValue);
 }
 
@@ -88,7 +88,7 @@ std::string Column::getString() const
 {
     // Note: using sqlite3_column_blob and not sqlite3_column_text
     // - no need for sqlite3_column_text to add a \0 on the end, as we're getting the bytes length directly
-    const char *data = static_cast<const char *>(sqlite3_column_blob(mStmtPtr.get(), mIndex));
+    auto data = static_cast<const char *>(sqlite3_column_blob(mStmtPtr.get(), mIndex));
 
     // SQLite docs: "The safest policy is to invoke… sqlite3_column_blob() followed by sqlite3_column_bytes()"
     // Note: std::string is ok to pass nullptr as first arg, if length is 0

--- a/src/Column.cpp
+++ b/src/Column.cpp
@@ -26,7 +26,7 @@ const int Null      = SQLITE_NULL;
 
 
 // Encapsulation of a Column in a row of the result pointed by the prepared Statement.
-Column::Column(Statement::Ptr& aStmtPtr, int aIndex) noexcept :
+Column::Column(Statement::TStatementPtr& aStmtPtr, int aIndex) noexcept :
     mStmtPtr(aStmtPtr),
     mIndex(aIndex)
 {
@@ -35,21 +35,21 @@ Column::Column(Statement::Ptr& aStmtPtr, int aIndex) noexcept :
 // Return the named assigned to this result column (potentially aliased)
 const char* Column::getName() const noexcept
 {
-    return sqlite3_column_name(mStmtPtr, mIndex);
+    return sqlite3_column_name(mStmtPtr.get(), mIndex);
 }
 
 #ifdef SQLITE_ENABLE_COLUMN_METADATA
 // Return the name of the table column that is the origin of this result column
 const char* Column::getOriginName() const noexcept
 {
-    return sqlite3_column_origin_name(mStmtPtr, mIndex);
+    return sqlite3_column_origin_name(mStmtPtr.get(), mIndex);
 }
 #endif
 
 // Return the integer value of the column specified by its index starting at 0
 int Column::getInt() const noexcept
 {
-    return sqlite3_column_int(mStmtPtr, mIndex);
+    return sqlite3_column_int(mStmtPtr.get(), mIndex);
 }
 
 // Return the unsigned integer value of the column specified by its index starting at 0
@@ -61,26 +61,26 @@ unsigned Column::getUInt() const noexcept
 // Return the 64bits integer value of the column specified by its index starting at 0
 long long Column::getInt64() const noexcept
 {
-    return sqlite3_column_int64(mStmtPtr, mIndex);
+    return sqlite3_column_int64(mStmtPtr.get(), mIndex);
 }
 
 // Return the double value of the column specified by its index starting at 0
 double Column::getDouble() const noexcept
 {
-    return sqlite3_column_double(mStmtPtr, mIndex);
+    return sqlite3_column_double(mStmtPtr.get(), mIndex);
 }
 
 // Return a pointer to the text value (NULL terminated string) of the column specified by its index starting at 0
 const char* Column::getText(const char* apDefaultValue /* = "" */) const noexcept
 {
-    const char* pText = reinterpret_cast<const char*>(sqlite3_column_text(mStmtPtr, mIndex));
+    const char* pText = reinterpret_cast<const char*>(sqlite3_column_text(mStmtPtr.get(), mIndex));
     return (pText?pText:apDefaultValue);
 }
 
 // Return a pointer to the blob value (*not* NULL terminated) of the column specified by its index starting at 0
 const void* Column::getBlob() const noexcept
 {
-    return sqlite3_column_blob(mStmtPtr, mIndex);
+    return sqlite3_column_blob(mStmtPtr.get(), mIndex);
 }
 
 // Return a std::string to a TEXT or BLOB column
@@ -88,23 +88,23 @@ std::string Column::getString() const
 {
     // Note: using sqlite3_column_blob and not sqlite3_column_text
     // - no need for sqlite3_column_text to add a \0 on the end, as we're getting the bytes length directly
-    const char *data = static_cast<const char *>(sqlite3_column_blob(mStmtPtr, mIndex));
+    const char *data = static_cast<const char *>(sqlite3_column_blob(mStmtPtr.get(), mIndex));
 
     // SQLite docs: "The safest policy is to invoke… sqlite3_column_blob() followed by sqlite3_column_bytes()"
     // Note: std::string is ok to pass nullptr as first arg, if length is 0
-    return std::string(data, sqlite3_column_bytes(mStmtPtr, mIndex));
+    return std::string(data, sqlite3_column_bytes(mStmtPtr.get(), mIndex));
 }
 
 // Return the type of the value of the column
 int Column::getType() const noexcept
 {
-    return sqlite3_column_type(mStmtPtr, mIndex);
+    return sqlite3_column_type(mStmtPtr.get(), mIndex);
 }
 
 // Return the number of bytes used by the text value of the column
 int Column::getBytes() const noexcept
 {
-    return sqlite3_column_bytes(mStmtPtr, mIndex);
+    return sqlite3_column_bytes(mStmtPtr.get(), mIndex);
 }
 
 // Standard std::ostream inserter

--- a/src/Column.cpp
+++ b/src/Column.cpp
@@ -26,7 +26,7 @@ const int Null      = SQLITE_NULL;
 
 
 // Encapsulation of a Column in a row of the result pointed by the prepared Statement.
-Column::Column(const Statement::TStatementPtr& aStmtPtr, int aIndex) noexcept :
+Column::Column(const Statement::TStatementPtr& aStmtPtr, int aIndex) :
     mStmtPtr(aStmtPtr),
     mIndex(aIndex)
 {

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -68,22 +68,22 @@ int Statement::getIndex(const char * const apName)
     return sqlite3_bind_parameter_index(mStmtPtr, apName);
 }
 
-// Bind an int value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
-void Statement::bind(const int aIndex, const int aValue)
+// Bind an 32bits int value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
+void Statement::bind(const int aIndex, const int32_t aValue)
 {
     const int ret = sqlite3_bind_int(mStmtPtr, aIndex, aValue);
     check(ret);
 }
 
 // Bind a 32bits unsigned int value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
-void Statement::bind(const int aIndex, const unsigned aValue)
+void Statement::bind(const int aIndex, const uint32_t aValue)
 {
     const int ret = sqlite3_bind_int64(mStmtPtr, aIndex, aValue);
     check(ret);
 }
 
 // Bind a 64bits int value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
-void Statement::bind(const int aIndex, const long long aValue)
+void Statement::bind(const int aIndex, const int64_t aValue)
 {
     const int ret = sqlite3_bind_int64(mStmtPtr, aIndex, aValue);
     check(ret);

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -22,21 +22,21 @@ namespace SQLite
 
 Statement::Statement(Database &aDatabase, const char* apQuery) :
     mQuery(apQuery),
-    mStmtPtr(aDatabase.getHandle(), mQuery), // prepare the SQL query, and ref count (needs Database friendship)
-    mColumnCount(0),
-    mbHasRow(false),
-    mbDone(false)
+    mpSQLite(aDatabase.getHandle()),
+    mpPreparedStatement(prepareStatement()) // prepare the SQL query (needs Database friendship)
 {
-    mColumnCount = sqlite3_column_count(mStmtPtr);
+    mColumnCount = sqlite3_column_count(mpPreparedStatement.get());
 }
 
 Statement::Statement(Statement&& aStatement) noexcept :
     mQuery(std::move(aStatement.mQuery)),
-    mStmtPtr(std::move(aStatement.mStmtPtr)),
+    mpSQLite(aStatement.mpSQLite),
+    mpPreparedStatement(std::move(aStatement.mpPreparedStatement)),
     mColumnCount(aStatement.mColumnCount),
     mbHasRow(aStatement.mbHasRow),
     mbDone(aStatement.mbDone)
 {
+    aStatement.mpSQLite = nullptr;
     aStatement.mColumnCount = 0;
     aStatement.mbHasRow = false;
     aStatement.mbDone = false;
@@ -53,53 +53,53 @@ int Statement::tryReset() noexcept
 {
     mbHasRow = false;
     mbDone = false;
-    return sqlite3_reset(mStmtPtr);
+    return sqlite3_reset(mpPreparedStatement.get());
 }
 
 // Clears away all the bindings of a prepared statement (can be associated with #reset() above).
 void Statement::clearBindings()
 {
-    const int ret = sqlite3_clear_bindings(mStmtPtr);
+    const int ret = sqlite3_clear_bindings(getPreparedStatement());
     check(ret);
 }
 
 int Statement::getIndex(const char * const apName)
 {
-    return sqlite3_bind_parameter_index(mStmtPtr, apName);
+    return sqlite3_bind_parameter_index(getPreparedStatement(), apName);
 }
 
 // Bind an 32bits int value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bind(const int aIndex, const int32_t aValue)
 {
-    const int ret = sqlite3_bind_int(mStmtPtr, aIndex, aValue);
+    const int ret = sqlite3_bind_int(getPreparedStatement(), aIndex, aValue);
     check(ret);
 }
 
 // Bind a 32bits unsigned int value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bind(const int aIndex, const uint32_t aValue)
 {
-    const int ret = sqlite3_bind_int64(mStmtPtr, aIndex, aValue);
+    const int ret = sqlite3_bind_int64(getPreparedStatement(), aIndex, aValue);
     check(ret);
 }
 
 // Bind a 64bits int value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bind(const int aIndex, const int64_t aValue)
 {
-    const int ret = sqlite3_bind_int64(mStmtPtr, aIndex, aValue);
+    const int ret = sqlite3_bind_int64(getPreparedStatement(), aIndex, aValue);
     check(ret);
 }
 
 // Bind a double (64bits float) value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bind(const int aIndex, const double aValue)
 {
-    const int ret = sqlite3_bind_double(mStmtPtr, aIndex, aValue);
+    const int ret = sqlite3_bind_double(getPreparedStatement(), aIndex, aValue);
     check(ret);
 }
 
 // Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bind(const int aIndex, const std::string& aValue)
 {
-    const int ret = sqlite3_bind_text(mStmtPtr, aIndex, aValue.c_str(),
+    const int ret = sqlite3_bind_text(getPreparedStatement(), aIndex, aValue.c_str(),
                                       static_cast<int>(aValue.size()), SQLITE_TRANSIENT);
     check(ret);
 }
@@ -107,21 +107,21 @@ void Statement::bind(const int aIndex, const std::string& aValue)
 // Bind a text value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bind(const int aIndex, const char* apValue)
 {
-    const int ret = sqlite3_bind_text(mStmtPtr, aIndex, apValue, -1, SQLITE_TRANSIENT);
+    const int ret = sqlite3_bind_text(getPreparedStatement(), aIndex, apValue, -1, SQLITE_TRANSIENT);
     check(ret);
 }
 
 // Bind a binary blob value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bind(const int aIndex, const void* apValue, const int aSize)
 {
-    const int ret = sqlite3_bind_blob(mStmtPtr, aIndex, apValue, aSize, SQLITE_TRANSIENT);
+    const int ret = sqlite3_bind_blob(getPreparedStatement(), aIndex, apValue, aSize, SQLITE_TRANSIENT);
     check(ret);
 }
 
 // Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bindNoCopy(const int aIndex, const std::string& aValue)
 {
-    const int ret = sqlite3_bind_text(mStmtPtr, aIndex, aValue.c_str(),
+    const int ret = sqlite3_bind_text(getPreparedStatement(), aIndex, aValue.c_str(),
                                       static_cast<int>(aValue.size()), SQLITE_STATIC);
     check(ret);
 }
@@ -129,21 +129,21 @@ void Statement::bindNoCopy(const int aIndex, const std::string& aValue)
 // Bind a text value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bindNoCopy(const int aIndex, const char* apValue)
 {
-    const int ret = sqlite3_bind_text(mStmtPtr, aIndex, apValue, -1, SQLITE_STATIC);
+    const int ret = sqlite3_bind_text(getPreparedStatement(), aIndex, apValue, -1, SQLITE_STATIC);
     check(ret);
 }
 
 // Bind a binary blob value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bindNoCopy(const int aIndex, const void* apValue, const int aSize)
 {
-    const int ret = sqlite3_bind_blob(mStmtPtr, aIndex, apValue, aSize, SQLITE_STATIC);
+    const int ret = sqlite3_bind_blob(getPreparedStatement(), aIndex, apValue, aSize, SQLITE_STATIC);
     check(ret);
 }
 
 // Bind a NULL value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bind(const int aIndex)
 {
-    const int ret = sqlite3_bind_null(mStmtPtr, aIndex);
+    const int ret = sqlite3_bind_null(getPreparedStatement(), aIndex);
     check(ret);
 }
 
@@ -154,9 +154,9 @@ bool Statement::executeStep()
     const int ret = tryExecuteStep();
     if ((SQLITE_ROW != ret) && (SQLITE_DONE != ret)) // on row or no (more) row ready, else it's a problem
     {
-        if (ret == sqlite3_errcode(mStmtPtr))
+        if (ret == sqlite3_errcode(mpSQLite))
         {
-            throw SQLite::Exception(mStmtPtr, ret);
+            throw SQLite::Exception(mpSQLite, ret);
         }
         else
         {
@@ -177,9 +177,9 @@ int Statement::exec()
         {
             throw SQLite::Exception("exec() does not expect results. Use executeStep.");
         }
-        else if (ret == sqlite3_errcode(mStmtPtr))
+        else if (ret == sqlite3_errcode(mpSQLite))
         {
-            throw SQLite::Exception(mStmtPtr, ret);
+            throw SQLite::Exception(mpSQLite, ret);
         }
         else
         {
@@ -188,36 +188,27 @@ int Statement::exec()
     }
 
     // Return the number of rows modified by those SQL statements (INSERT, UPDATE or DELETE)
-    return sqlite3_changes(mStmtPtr);
+    return sqlite3_changes(mpSQLite);
 }
 
 int Statement::tryExecuteStep() noexcept
 {
-    if (false == mbDone)
+    if (mbDone)
     {
-        const int ret = sqlite3_step(mStmtPtr);
-        if (SQLITE_ROW == ret) // one row is ready : call getColumn(N) to access it
-        {
-            mbHasRow = true;
-        }
-        else if (SQLITE_DONE == ret) // no (more) row ready : the query has finished executing
-        {
-            mbHasRow = false;
-            mbDone = true;
-        }
-        else
-        {
-            mbHasRow = false;
-            mbDone = false;
-        }
+        return SQLITE_MISUSE; // Statement needs to be reseted !
+    }
 
-        return ret;
+    const int ret = sqlite3_step(mpPreparedStatement.get());
+    if (SQLITE_ROW == ret) // one row is ready : call getColumn(N) to access it
+    {
+        mbHasRow = true;
     }
     else
     {
-        // Statement needs to be reseted !
-        return SQLITE_MISUSE;
+        mbHasRow = false;
+        mbDone = SQLITE_DONE == ret; // check if the query has finished executing
     }
+    return ret;
 }
 
 
@@ -229,7 +220,7 @@ Column Statement::getColumn(const int aIndex)
     checkIndex(aIndex);
 
     // Share the Statement Object handle with the new Column created
-    return Column(mStmtPtr, aIndex);
+    return Column(mpPreparedStatement, aIndex);
 }
 
 // Return a copy of the column data specified by its column name starting at 0
@@ -240,7 +231,7 @@ Column  Statement::getColumn(const char* apName)
     const int index = getColumnIndex(apName);
 
     // Share the Statement Object handle with the new Column created
-    return Column(mStmtPtr, index);
+    return Column(mpPreparedStatement, index);
 }
 
 // Test if the column is NULL
@@ -248,21 +239,21 @@ bool Statement::isColumnNull(const int aIndex) const
 {
     checkRow();
     checkIndex(aIndex);
-    return (SQLITE_NULL == sqlite3_column_type(mStmtPtr, aIndex));
+    return (SQLITE_NULL == sqlite3_column_type(getPreparedStatement(), aIndex));
 }
 
 bool Statement::isColumnNull(const char* apName) const
 {
     checkRow();
     const int index = getColumnIndex(apName);
-    return (SQLITE_NULL == sqlite3_column_type(mStmtPtr, index));
+    return (SQLITE_NULL == sqlite3_column_type(getPreparedStatement(), index));
 }
 
 // Return the named assigned to the specified result column (potentially aliased)
 const char* Statement::getColumnName(const int aIndex) const
 {
     checkIndex(aIndex);
-    return sqlite3_column_name(mStmtPtr, aIndex);
+    return sqlite3_column_name(getPreparedStatement(), aIndex);
 }
 
 #ifdef SQLITE_ENABLE_COLUMN_METADATA
@@ -270,7 +261,7 @@ const char* Statement::getColumnName(const int aIndex) const
 const char* Statement::getColumnOriginName(const int aIndex) const
 {
     checkIndex(aIndex);
-    return sqlite3_column_origin_name(mStmtPtr, aIndex);
+    return sqlite3_column_origin_name(getPreparedStatement(), aIndex);
 }
 #endif
 
@@ -282,7 +273,7 @@ int Statement::getColumnIndex(const char* apName) const
     {
         for (int i = 0; i < mColumnCount; ++i)
         {
-            const char* pName = sqlite3_column_name(mStmtPtr, i);
+            const char* pName = sqlite3_column_name(getPreparedStatement(), i);
             mColumnNames[pName] = i;
         }
     }
@@ -299,7 +290,7 @@ int Statement::getColumnIndex(const char* apName) const
 const char * Statement::getColumnDeclaredType(const int aIndex) const
 {
     checkIndex(aIndex);
-    const char * result = sqlite3_column_decltype(mStmtPtr, aIndex);
+    const char * result = sqlite3_column_decltype(getPreparedStatement(), aIndex);
     if (!result)
     {
         throw SQLite::Exception("Could not determine declared column type.");
@@ -313,119 +304,64 @@ const char * Statement::getColumnDeclaredType(const int aIndex) const
 // Get number of rows modified by last INSERT, UPDATE or DELETE statement (not DROP table).
 int Statement::getChanges() const noexcept
 {
-    return sqlite3_changes(mStmtPtr);
+    return sqlite3_changes(mpSQLite);
 }
 
 int Statement::getBindParameterCount() const noexcept
 {
-    return sqlite3_bind_parameter_count(mStmtPtr);
+    return sqlite3_bind_parameter_count(mpPreparedStatement.get());
 }
 
 // Return the numeric result code for the most recent failed API call (if any).
 int Statement::getErrorCode() const noexcept
 {
-    return sqlite3_errcode(mStmtPtr);
+    return sqlite3_errcode(mpSQLite);
 }
 
 // Return the extended numeric result code for the most recent failed API call (if any).
 int Statement::getExtendedErrorCode() const noexcept
 {
-    return sqlite3_extended_errcode(mStmtPtr);
+    return sqlite3_extended_errcode(mpSQLite);
 }
 
 // Return UTF-8 encoded English language explanation of the most recent failed API call (if any).
 const char* Statement::getErrorMsg() const noexcept
 {
-    return sqlite3_errmsg(mStmtPtr);
+    return sqlite3_errmsg(mpSQLite);
 }
 
 // Return a UTF-8 string containing the SQL text of prepared statement with bound parameters expanded.
 std::string Statement::getExpandedSQL() {
-    char* expanded = sqlite3_expanded_sql(mStmtPtr);
+    char* expanded = sqlite3_expanded_sql(getPreparedStatement());
     std::string expandedString(expanded);
     sqlite3_free(expanded);
     return expandedString;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// Internal class : shared pointer to the sqlite3_stmt SQLite Statement Object
-////////////////////////////////////////////////////////////////////////////////
-
-/**
- * @brief Prepare the statement and initialize its reference counter
- *
- * @param[in] apSQLite  The sqlite3 database connexion
- * @param[in] aQuery    The SQL query string to prepare
- */
-Statement::Ptr::Ptr(sqlite3* apSQLite, std::string& aQuery) :
-    mpSQLite(apSQLite),
-    mpStmt(NULL),
-    mpRefCount(NULL)
+// Prepare SQLite statement object and return shared pointer to this object
+Statement::TStatementPtr Statement::prepareStatement()
 {
-    const int ret = sqlite3_prepare_v2(apSQLite, aQuery.c_str(), static_cast<int>(aQuery.size()), &mpStmt, NULL);
+    sqlite3_stmt* statement;
+    const int ret = sqlite3_prepare_v2(mpSQLite, mQuery.c_str(), static_cast<int>(mQuery.size()), &statement, NULL);
     if (SQLITE_OK != ret)
     {
-        throw SQLite::Exception(apSQLite, ret);
+        throw SQLite::Exception(mpSQLite, ret);
     }
-    // Initialize the reference counter of the sqlite3_stmt :
-    // used to share the mStmtPtr between Statement and Column objects;
-    // This is needed to enable Column objects to live longer than the Statement objet it refers to.
-    mpRefCount = new unsigned int(1);  // NOLINT(readability/casting)
-}
-
-/**
- * @brief Copy constructor increments the ref counter
- *
- * @param[in] aPtr Pointer to copy
- */
-Statement::Ptr::Ptr(const Statement::Ptr& aPtr) :
-    mpSQLite(aPtr.mpSQLite),
-    mpStmt(aPtr.mpStmt),
-    mpRefCount(aPtr.mpRefCount)
-{
-    assert(mpRefCount);
-    assert(0 != *mpRefCount);
-
-    // Increment the reference counter of the sqlite3_stmt,
-    // asking not to finalize the sqlite3_stmt during the lifetime of the new objet
-    ++(*mpRefCount);
-}
-
-Statement::Ptr::Ptr(Ptr&& aPtr) :
-    mpSQLite(aPtr.mpSQLite),
-    mpStmt(aPtr.mpStmt),
-    mpRefCount(aPtr.mpRefCount)
-{
-    aPtr.mpSQLite = nullptr;
-    aPtr.mpStmt = nullptr;
-    aPtr.mpRefCount = nullptr;
-}
-
-/**
- * @brief Decrement the ref counter and finalize the sqlite3_stmt when it reaches 0
- */
-Statement::Ptr::~Ptr()
-{
-    if (mpRefCount)
-    {
-        assert(0 != *mpRefCount);
-
-        // Decrement and check the reference counter of the sqlite3_stmt
-        --(*mpRefCount);
-        if (0 == *mpRefCount)
+    return Statement::TStatementPtr(statement, [](sqlite3_stmt* stmt)
         {
-            // If count reaches zero, finalize the sqlite3_stmt, as no Statement nor Column objet use it anymore.
-            // No need to check the return code, as it is the same as the last statement evaluation.
-            sqlite3_finalize(mpStmt);
-
-            // and delete the reference counter
-            delete mpRefCount;
-            mpRefCount = nullptr;
-            mpStmt = nullptr;
-        }
-        // else, the finalization will be done later, by the last object
-    }
+            sqlite3_finalize(stmt);
+        });
 }
 
+// Return prepered statement object or throw
+sqlite3_stmt* Statement::getPreparedStatement() const
+{
+    sqlite3_stmt* ret = mpPreparedStatement.get();
+    if (ret)
+    {
+        return ret;
+    }
+    throw SQLite::Exception("Statement was not prepared.");
+}
 
 }  // namespace SQLite

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -28,20 +28,6 @@ Statement::Statement(Database &aDatabase, const char* apQuery) :
     mColumnCount = sqlite3_column_count(mpPreparedStatement.get());
 }
 
-Statement::Statement(Statement&& aStatement) noexcept :
-    mQuery(std::move(aStatement.mQuery)),
-    mpSQLite(aStatement.mpSQLite),
-    mpPreparedStatement(std::move(aStatement.mpPreparedStatement)),
-    mColumnCount(aStatement.mColumnCount),
-    mbHasRow(aStatement.mbHasRow),
-    mbDone(aStatement.mbDone)
-{
-    aStatement.mpSQLite = nullptr;
-    aStatement.mColumnCount = 0;
-    aStatement.mbHasRow = false;
-    aStatement.mbDone = false;
-}
-
 // Reset the statement to make it ready for a new execution (see also #clearBindings() bellow)
 void Statement::reset()
 {
@@ -342,7 +328,7 @@ std::string Statement::getExpandedSQL() {
 Statement::TStatementPtr Statement::prepareStatement()
 {
     sqlite3_stmt* statement;
-    const int ret = sqlite3_prepare_v2(mpSQLite, mQuery.c_str(), static_cast<int>(mQuery.size()), &statement, NULL);
+    const int ret = sqlite3_prepare_v2(mpSQLite, mQuery.c_str(), static_cast<int>(mQuery.size()), &statement, nullptr);
     if (SQLITE_OK != ret)
     {
         throw SQLite::Exception(mpSQLite, ret);

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -28,6 +28,21 @@ Statement::Statement(const Database& aDatabase, const char* apQuery) :
     mColumnCount = sqlite3_column_count(mpPreparedStatement.get());
 }
 
+Statement::Statement(Statement&& aStatement) noexcept :
+    mQuery(std::move(aStatement.mQuery)),
+    mpSQLite(aStatement.mpSQLite),
+    mpPreparedStatement(std::move(aStatement.mpPreparedStatement)),
+    mColumnCount(aStatement.mColumnCount),
+    mbHasRow(aStatement.mbHasRow),
+    mbDone(aStatement.mbDone),
+    mColumnNames(std::move(aStatement.mColumnNames))
+{
+    aStatement.mpSQLite = nullptr;
+    aStatement.mColumnCount = 0;
+    aStatement.mbHasRow = false;
+    aStatement.mbDone = false;
+}
+
 // Reset the statement to make it ready for a new execution (see also #clearBindings() bellow)
 void Statement::reset()
 {

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -20,7 +20,7 @@
 namespace SQLite
 {
 
-Statement::Statement(Database &aDatabase, const char* apQuery) :
+Statement::Statement(const Database& aDatabase, const char* apQuery) :
     mQuery(apQuery),
     mpSQLite(aDatabase.getHandle()),
     mpPreparedStatement(prepareStatement()) // prepare the SQL query (needs Database friendship)
@@ -49,7 +49,7 @@ void Statement::clearBindings()
     check(ret);
 }
 
-int Statement::getIndex(const char * const apName)
+int Statement::getIndex(const char * const apName) const
 {
     return sqlite3_bind_parameter_index(getPreparedStatement(), apName);
 }
@@ -200,7 +200,7 @@ int Statement::tryExecuteStep() noexcept
 
 // Return a copy of the column data specified by its index starting at 0
 // (use the Column copy-constructor)
-Column Statement::getColumn(const int aIndex)
+Column Statement::getColumn(const int aIndex) const
 {
     checkRow();
     checkIndex(aIndex);
@@ -211,7 +211,7 @@ Column Statement::getColumn(const int aIndex)
 
 // Return a copy of the column data specified by its column name starting at 0
 // (use the Column copy-constructor)
-Column  Statement::getColumn(const char* apName)
+Column Statement::getColumn(const char* apName) const
 {
     checkRow();
     const int index = getColumnIndex(apName);
@@ -317,7 +317,7 @@ const char* Statement::getErrorMsg() const noexcept
 }
 
 // Return a UTF-8 string containing the SQL text of prepared statement with bound parameters expanded.
-std::string Statement::getExpandedSQL() {
+std::string Statement::getExpandedSQL() const {
     char* expanded = sqlite3_expanded_sql(getPreparedStatement());
     std::string expandedString(expanded);
     sqlite3_free(expanded);

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -264,13 +264,13 @@ int Statement::getColumnIndex(const char* apName) const
         }
     }
 
-    const TColumnNames::const_iterator iIndex = mColumnNames.find(apName);
+    const auto iIndex = mColumnNames.find(apName);
     if (iIndex == mColumnNames.end())
     {
         throw SQLite::Exception("Unknown column name.");
     }
 
-    return (*iIndex).second;
+    return iIndex->second;
 }
 
 const char * Statement::getColumnDeclaredType(const int aIndex) const

--- a/tests/Statement_test.cpp
+++ b/tests/Statement_test.cpp
@@ -119,7 +119,6 @@ TEST(Statement, moveConstructor)
     EXPECT_EQ(2, query.getColumnCount());
     SQLite::Statement moved = std::move(query);
     EXPECT_TRUE(query.getQuery().empty());
-    EXPECT_EQ(0, query.getColumnCount());
     EXPECT_FALSE(moved.getQuery().empty());
     EXPECT_EQ(2, moved.getColumnCount());
     // Execute
@@ -128,6 +127,16 @@ TEST(Statement, moveConstructor)
     EXPECT_FALSE(moved.isDone());
     EXPECT_FALSE(query.hasRow());
     EXPECT_FALSE(query.isDone());
+
+    // Const statement lookup
+    const auto const_query = std::move(moved);
+    auto index = const_query.getColumnIndex("value");
+    EXPECT_EQ(1, index);
+    EXPECT_NO_THROW(const_query.getColumn(index));
+
+    // Moved statements should throw
+    EXPECT_THROW(query.getColumnIndex("value"), SQLite::Exception);
+    EXPECT_THROW(query.getColumn(index), SQLite::Exception);
 }
 
 #endif


### PR DESCRIPTION
As title says I refactored Statement and Columns with minimal changes to wrapper API.
List of all major changes:

- [x] **Replaced macro long size checks with _fixed width ints_ for Statement::bind**
(Macros are still needed for "operator long" in Columns but not in Statement binds methods. Fixed width ints should properly detect size of long function parameter)
- [x] **Replaced Statement::Ptr with std::shared_ptr<sqlite3_stmt>** (aliased as TStatementPtr) - need for this was mentioned [there](https://github.com/SRombauts/SQLiteCpp/blob/ce6dd9b82234e0427801380286d87f5bae417cca/include/SQLiteCpp/Statement.h#L712).
- [x] **Added Statement move assignment** (and so fixing #347 )
- [x] **Column throws when created with empty pointer to prepered statement.** 
- [x] **Statement methods: getIndex, getColumn, getExpandedSQL are now const**