### PR TITLE
add basic meson support.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,188 @@
+project(
+    'SQLiteCpp', 'cpp',
+    # SQLiteCpp requires C++11 support
+    default_options: ['cpp_std=c++11'],
+    license: 'MIT',
+    version: '3.1.1',
+)
+
+cxx = meson.get_compiler('cpp')
+
+## at best we might try to test if this code compiles
+## testing for compilers or platforms is not reliable enough
+## example: native clang on windows or mingw in windows
+unix_like_code = '''
+    #if defined(unix) || defined(__unix__) || defined(__unix)
+    // do nothing
+    #else
+    # error "Non Unix-like OS"
+    #endif
+'''
+unix_like = cxx.compiles(unix_like_code, name : 'unix like environment')
+
+thread_dep = dependency('threads')
+# sqlite3 support
+sqlite3_dep = dependency(
+                'sqlite3',
+                fallback: ['sqlite3', 'sqlite3_dep']
+)
+
+sqlitecpp_incl = [ 
+    include_directories('include')
+]
+sqlitecpp_srcs = [
+    'src/Backup.cpp',
+    'src/Column.cpp',
+    'src/Database.cpp',
+    'src/Exception.cpp',
+    'src/Statement.cpp',
+    'src/Transaction.cpp',
+]
+sqlitecpp_args = [
+    '-Wall',
+]
+sqlitecpp_link = []
+sqlitecpp_deps = [
+    sqlite3_dep,
+    thread_dep,
+]
+
+## tests
+
+sqlitecpp_test_srcs = [
+    'tests/Column_test.cpp',
+    'tests/Database_test.cpp',
+    'tests/Statement_test.cpp',
+    'tests/Backup_test.cpp',
+    'tests/Transaction_test.cpp',
+    'tests/VariadicBind_test.cpp',
+    'tests/Exception_test.cpp',
+    'tests/ExecuteMany_test.cpp',
+]
+
+## samples
+
+sqlitecpp_sample_srcs = [
+    'examples/example1/main.cpp',
+]
+
+# if not using MSVC we need to add this compiler arguments
+# for a list of MSVC supported arguments please check:
+# https://docs.microsoft.com/en-us/cpp/build/reference/compiler-options-listed-alphabetically?view=msvc-170
+if not (host_machine.system() == 'windows' and cxx.get_id() == 'msvc')
+    sqlitecpp_args += [
+        '-Wextra',
+        '-Wpedantic',
+        '-Wswitch-enum',
+        '-Wshadow',
+        '-Wno-long-long',
+    ]
+endif
+
+# Options relative to SQLite and SQLiteC++ functions
+
+if get_option('SQLITE_ENABLE_COLUMN_METADATA')
+    sqlitecpp_args += [
+        '-DSQLITE_ENABLE_COLUMN_METADATA',
+    ]
+endif
+
+if get_option('SQLITE_ENABLE_ASSERT_HANDLER')
+    sqlitecpp_args += [
+        '-DSQLITE_ENABLE_ASSERT_HANDLER',
+    ]
+endif
+
+if get_option('SQLITE_HAS_CODEC')
+    sqlitecpp_args += [
+        'SQLITE_HAS_CODEC',
+    ]
+endif
+
+if get_option('SQLITE_USE_LEGACY_STRUCT')
+    sqlitecpp_args += [
+        '-DSQLITE_USE_LEGACY_STRUCT',
+    ] 
+endif
+
+if unix_like
+    sqlitecpp_args += [
+        '-DfPIC',
+    ]
+    # add dl dependency
+    libdl_dep = cxx.find_library('dl')
+    sqlitecpp_deps += [
+        libdl_dep,
+    ]
+endif
+
+if get_option('b_coverage')
+    # Prevent the compiler from removing the unused inline functions so that they get tracked as "non-covered"
+    sqlitecpp_args += [
+        '-fkeep-inline-functions',
+        '-fkeep-static-functions',
+    ]
+endif
+
+
+libsqlitecpp = library(
+    'sqlitecpp',
+    sqlitecpp_srcs,
+    include_directories: sqlitecpp_incl,
+    cpp_args: sqlitecpp_args,
+    dependencies: sqlitecpp_deps,
+    # install: true,
+    # API version for SQLiteCpp shared library.
+    version: '0',
+)
+
+install_headers(
+    'include/SQLiteCpp/SQLiteCpp.h',
+    'include/SQLiteCpp/Assertion.h',
+    'include/SQLiteCpp/Backup.h',
+    'include/SQLiteCpp/Column.h',
+    'include/SQLiteCpp/Database.h',
+    'include/SQLiteCpp/Exception.h',
+    'include/SQLiteCpp/Statement.h',
+    'include/SQLiteCpp/Transaction.h',
+    'include/SQLiteCpp/VariadicBind.h',
+    'include/SQLiteCpp/ExecuteMany.h',
+)
+
+sqlitecpp_dep = declare_dependency(
+    include_directories: sqlitecpp_incl,
+    link_with: libsqlitecpp,
+)
+
+if get_option('SQLITECPP_BUILD_TESTS')
+    gtest_dep = dependency(
+                'gtest',
+                main : true,
+                fallback: ['gtest', 'gtest_dep'])
+    sqlitecpp_test_dependencies = [
+        gtest_dep,
+        sqlitecpp_dep,
+        sqlite3_dep,
+    ]
+    sqlitecpp_test_args = []
+
+    testexe = executable('testexe', sqlitecpp_test_srcs,
+                     dependencies: sqlitecpp_test_dependencies)
+
+    test_args = []
+
+    test('sqlitecpp unit tests', testexe, args: test_args)
+endif
+if get_option('SQLITECPP_BUILD_EXAMPLES')
+    ## demo executable
+    sqlitecpp_demo_exe = executable('SQLITECPP_sample_demo',
+                            sqlitecpp_sample_srcs,
+                            dependencies: sqlitecpp_dep)
+endif
+
+pkgconfig = import('pkgconfig')
+pkgconfig.generate(
+    libsqlitecpp,
+    description: 'a smart and easy to use C++ SQLite3 wrapper.',
+    version: meson.project_version(),
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,13 @@
+# Options relative to SQLite and SQLiteC++ functions
+## Enable the use of SQLite column metadata and Column::getColumnOriginName() method,
+## Require that the sqlite3 library is also compiled with this flag (default under Debian/Ubuntu, but not on Mac OS X).
+option('SQLITE_ENABLE_COLUMN_METADATA', type: 'boolean', value: false, description: 'Enable Column::getColumnOriginName(). Require support from sqlite3 library.')
+## Enable the user definition of a assertion_failed() handler (default to false, easier to handler for beginners).
+option('SQLITE_ENABLE_ASSERT_HANDLER', type: 'boolean', value: false, description: 'Enable the user definition of a assertion_failed() handler.')
+## Enable database encryption API. Requires implementations of sqlite3_key & sqlite3_key_v2.
+## Eg. SQLCipher (libsqlcipher-dev) is an SQLite extension that provides 256 bit AES encryption of database files. 
+option('SQLITE_HAS_CODEC', type: 'boolean', value: false, description: 'Enable database encryption API. Not available in the public release of SQLite.')
+## Force forward declaration of legacy struct sqlite3_value (pre SQLite 3.19)
+option('SQLITE_USE_LEGACY_STRUCT', type: 'boolean', value: false, description: 'Fallback to forward declaration of legacy struct sqlite3_value (pre SQLite 3.19)')
+option('SQLITECPP_BUILD_TESTS', type: 'boolean', value: false, description: 'Build SQLiteC++ unit tests.')
+option('SQLITECPP_BUILD_EXAMPLES', type: 'boolean', value: false, description: 'Build SQLiteC++ examples.')

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,0 +1,5 @@
+#ignore everything here
+*
+# but not the wrap files and the .gitignore
+!*.wrap
+!*.gitignore

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = googletest-release-1.11.0
+source_url = https://github.com/google/googletest/archive/release-1.11.0.tar.gz
+source_filename = gtest-1.11.0.tar.gz
+source_hash = b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5
+patch_directory = gtest
+
+[provide]
+gtest = gtest_dep
+gtest_main = gtest_main_dep
+gmock = gmock_dep
+gmock_main = gmock_main_dep

--- a/subprojects/sqlite3.wrap
+++ b/subprojects/sqlite3.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = sqlite-amalgamation-3380000
+source_url = https://sqlite.org/2022/sqlite-amalgamation-3380000.zip
+source_filename = sqlite-amalgamation-3380000.zip
+source_hash = e055f6054e97747a135c89e36520c0a423249e8a91c5fc445163f4a6adb20df6
+patch_filename = sqlite3_3.38.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sqlite3_3.38.0-1/get_patch
+patch_hash = 49e30bf010ff63ab772d5417885e6905379025ceac80382e292c6dbd3a9da744
+
+[provide]
+sqlite3 = sqlite3_dep
+


### PR DESCRIPTION
This PR adds basic meson support, at the moment it does not compile on windows, however managed it to compile on Arch Linux, when the Windows support is ready it should fix also #53,#280 and add maybe put it on wrapdb fixing #97.