### PR TITLE
Windows improved support (meson)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -84,7 +84,14 @@ if not (host_machine.system() == 'windows' and cxx.get_id() == 'msvc')
         '-Wno-long-long',
     ]
 endif
-
+## using MSVC headers requires c++14, if not will show an error on xstddef as: 
+## 'auto' return without trailing return type; deduced return types are a C++14 extension
+if host_machine.system() == 'windows'
+    message('[WINDOWS] using c++14 standard')
+    sqlitecpp_opts += [
+        'cpp_std=c++14',
+    ]
+endif
 # Options relative to SQLite and SQLiteC++ functions
 
 if get_option('SQLITE_ENABLE_COLUMN_METADATA')

--- a/meson.build
+++ b/meson.build
@@ -149,6 +149,18 @@ libsqlitecpp = library(
     # install: true,
     # API version for SQLiteCpp shared library.
     version: '0',)
+if get_option('SQLITECPP_BUILD_TESTS')
+    # for the unit tests we need to link against a static version of SQLiteCpp
+    libsqlitecpp_static = static_library(
+        'sqlitecpp_static',
+        sqlitecpp_srcs,
+        include_directories: sqlitecpp_incl,
+        cpp_args: sqlitecpp_args,
+        dependencies: sqlitecpp_deps,
+        # override the default options
+        override_options: sqlitecpp_opts,)
+        # static libraries do not have a version
+endif
 
 install_headers(
     'include/SQLiteCpp/SQLiteCpp.h',
@@ -167,6 +179,14 @@ sqlitecpp_dep = declare_dependency(
     include_directories: sqlitecpp_incl,
     link_with: libsqlitecpp,
 )
+if get_option('SQLITECPP_BUILD_TESTS')
+    ## make the dependency static so the unit tests can link against it
+    ## (mainly for windows as the symbols are not exported by default)
+    sqlitecpp_static_dep = declare_dependency(
+        include_directories: sqlitecpp_incl,
+        link_with: libsqlitecpp_static,
+    )
+endif
 
 if get_option('SQLITECPP_BUILD_TESTS')
     gtest_dep = dependency(
@@ -175,7 +195,7 @@ if get_option('SQLITECPP_BUILD_TESTS')
                 fallback: ['gtest', 'gtest_dep'])
     sqlitecpp_test_dependencies = [
         gtest_dep,
-        sqlitecpp_dep,
+        sqlitecpp_static_dep,
         sqlite3_dep,
     ]
 

--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,8 @@ sqlitecpp_deps = [
     sqlite3_dep,
     thread_dep,
 ]
+## used to override the default sqlitecpp options like cpp standard
+sqlitecpp_opts = []
 
 ## tests
 
@@ -58,6 +60,10 @@ sqlitecpp_test_srcs = [
     'tests/VariadicBind_test.cpp',
     'tests/Exception_test.cpp',
     'tests/ExecuteMany_test.cpp',
+]
+sqlitecpp_test_args = [
+    # do not use ambiguous overloads by default
+    '-DNON_AMBIGOUS_OVERLOAD'
 ]
 
 ## samples
@@ -131,10 +137,11 @@ libsqlitecpp = library(
     include_directories: sqlitecpp_incl,
     cpp_args: sqlitecpp_args,
     dependencies: sqlitecpp_deps,
+    # override the default options
+    override_options: sqlitecpp_opts,
     # install: true,
     # API version for SQLiteCpp shared library.
-    version: '0',
-)
+    version: '0',)
 
 install_headers(
     'include/SQLiteCpp/SQLiteCpp.h',
@@ -164,10 +171,12 @@ if get_option('SQLITECPP_BUILD_TESTS')
         sqlitecpp_dep,
         sqlite3_dep,
     ]
-    sqlitecpp_test_args = []
 
     testexe = executable('testexe', sqlitecpp_test_srcs,
-                     dependencies: sqlitecpp_test_dependencies)
+                     dependencies: sqlitecpp_test_dependencies,
+                     cpp_args: sqlitecpp_test_args,
+                     # override the default options
+                     override_options: sqlitecpp_opts,)
 
     test_args = []
 
@@ -177,7 +186,9 @@ if get_option('SQLITECPP_BUILD_EXAMPLES')
     ## demo executable
     sqlitecpp_demo_exe = executable('SQLITECPP_sample_demo',
                             sqlitecpp_sample_srcs,
-                            dependencies: sqlitecpp_dep)
+                            dependencies: sqlitecpp_dep,
+                            # override the default options
+                            override_options: sqlitecpp_opts,)
 endif
 
 pkgconfig = import('pkgconfig')

--- a/tests/Statement_test.cpp
+++ b/tests/Statement_test.cpp
@@ -374,7 +374,12 @@ TEST(Statement, bindings)
     // Sixth row with uint32_t unsigned value and a long value (which is either a 32b int or a 64b long long)
     {
         const uint32_t  uint32 = 4294967295U;
+        // preprocessor define to force not use long and use instead uint
+        #if NON_AMBIGOUS_OVERLOAD
+        const int       integer = -123;
+        #else
         const long      integer = -123;
+        #endif
         insert.bind(2, uint32);
         insert.bind(3, integer);
         EXPECT_EQ(1, insert.exec());
@@ -493,7 +498,11 @@ TEST(Statement, bindByName)
     {
         const std::string   second("second");
         const int64_t       int64 = 12345678900000LL;
+        #if NON_AMBIGOUS_OVERLOAD
+        const int           integer = -123;
+        #else
         const long          integer = -123;
+        #endif
         const float         float32 = 0.234f;
         insert.bind("@msg",      second);
         insert.bind("@int",      int64);
@@ -606,7 +615,11 @@ TEST(Statement, bindByNameString)
     {
         const std::string   second("second");
         const int64_t       int64 = 12345678900000LL;
+        #if NON_AMBIGOUS_OVERLOAD
+        const int           integer = -123;
+        #else
         const long          integer = -123;
+        #endif
         const float         float32 = 0.234f;
         insert.bind(amsg, second);
         insert.bind(aint, int64);

--- a/tests/Statement_test.cpp
+++ b/tests/Statement_test.cpp
@@ -12,6 +12,7 @@
 #include <SQLiteCpp/Database.h>
 #include <SQLiteCpp/Statement.h>
 
+#include <cstdint>   // for int64_t
 #include <sqlite3.h> // for SQLITE_DONE
 
 #include <gtest/gtest.h>
@@ -327,7 +328,7 @@ TEST(Statement, bindings)
     // Fourth row with string/int64/float
     {
         const std::string   fourth("fourth");
-        const long long     int64 = 12345678900000LL;
+        const int64_t       int64 = 12345678900000LL;
         const float         float32 = 0.234f;
         insert.bind(1, fourth);
         insert.bind(2, int64);
@@ -491,7 +492,7 @@ TEST(Statement, bindByName)
     // Second row with string/int64/float
     {
         const std::string   second("second");
-        const long long     int64 = 12345678900000LL;
+        const int64_t       int64 = 12345678900000LL;
         const long          integer = -123;
         const float         float32 = 0.234f;
         insert.bind("@msg",      second);
@@ -604,7 +605,7 @@ TEST(Statement, bindByNameString)
     // Second row with string/int64/float
     {
         const std::string   second("second");
-        const long long     int64 = 12345678900000LL;
+        const int64_t       int64 = 12345678900000LL;
         const long          integer = -123;
         const float         float32 = 0.234f;
         insert.bind(amsg, second);


### PR DESCRIPTION
this PR is an improvement of #352, managing to compile statically and run unit tests successfully on windows.
a summary of the changes in this PR:

- Meson file
  - use c++14 on windows(due to an error with xstddef)
  - add a preprocessor definition ('NON_AMBIGOUS_OVERLOAD') to use int instead of long to prevent ambiguous overload when compiling with clang++, it does not affect cmake and it only is enabled on meson
- Unit tests
  -  tests/Statement_test.cpp -> use "int64_t"(supported on c++11) instead of "long long" to prevent ambiguous overload errors (tested both on Arch Linux & Windows w clang)
  - tests/Statement_test.cpp -> check if NON_AMBIGOUS_OVERLOAD is defined and use int instead of long if is the case (to prevent ambiguous overload on windows)

the library still does not compile dynamically (as windows does not export the functions by default), so that should be fixed on an 3rd PR potentially fixing #280 and #53 for both meson and cmake, but this is a start before working on adding a macro for that feature.

after the dynamic compilation on windows is fixed, we could put the package on wrapdb so more users can use it easily.
