### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,21 @@ git submodule init
 git submodule update
 ```
 
+### Installing SQLiteCpp (vcpkg)
+
+Alternatively, you can build and install SQLiteCpp using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+```bash or powershell
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install sqlitecpp
+```
+
+The SQLiteCpp port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
+
 #### Using SQLiteCpp on a system-wide installation
 
 If you installed this package to your system, a `SQLiteCppConfig.cmake` file will be generated & installed to your system.  


### PR DESCRIPTION
`SQLiteCpp` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `SQLiteCpp`  and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `SQLiteCpp` , ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/sqlitecpp/portfile.cmake). We try to keep the library maintained as close as possible to the original library. 😊