### PR TITLE
add an option that could let the user decide whether to install SQLit…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,30 +310,34 @@ target_include_directories(SQLiteCpp
     $<INSTALL_INTERFACE:include/>)
 
 # Allow the library to be installed via "make install" and found with "find_package"
+# An option that could let the user decide whether to install SQLiteCpp or not.
 
-include(GNUInstallDirs)
-install(TARGETS SQLiteCpp
-    EXPORT ${PROJECT_NAME}Targets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    COMPONENT libraries)
-install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT headers FILES_MATCHING REGEX ".*\\.(hpp|h)$")
-install(EXPORT ${PROJECT_NAME}Targets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
-install(FILES ${PROJECT_SOURCE_DIR}/package.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
+option(SQLITECPP_INSTALL "Install SQLiteCpp." ON)
+if(SQLITECPP_INSTALL)
+    include(GNUInstallDirs)
+    install(TARGETS SQLiteCpp
+        EXPORT ${PROJECT_NAME}Targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT libraries)
+    install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT headers FILES_MATCHING REGEX ".*\\.(hpp|h)$")
+    install(EXPORT ${PROJECT_NAME}Targets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+    install(FILES ${PROJECT_SOURCE_DIR}/package.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
 
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-    cmake/${PROJECT_NAME}ConfigVersion.cmake
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY AnyNewerVersion)
-configure_package_config_file(
-    cmake/${PROJECT_NAME}Config.cmake.in
-    cmake/${PROJECT_NAME}Config.cmake
-    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
-install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file(
+        cmake/${PROJECT_NAME}ConfigVersion.cmake
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY AnyNewerVersion)
+    configure_package_config_file(
+        cmake/${PROJECT_NAME}Config.cmake.in
+        cmake/${PROJECT_NAME}Config.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+    install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+endif(SQLITECPP_INSTALL)
 
 # Optional additional targets:
 

--- a/sqlite3/CMakeLists.txt
+++ b/sqlite3/CMakeLists.txt
@@ -52,11 +52,12 @@ if (UNIX AND CMAKE_COMPILER_IS_GNUCXX)
 endif()
 
 # Allow the library to be installed via "make install" and found with "find_package"
-
-include(GNUInstallDirs)
-install(TARGETS sqlite3
-    EXPORT ${PROJECT_NAME}Targets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    COMPONENT libraries)
-install(FILES sqlite3.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT headers)
+if(SQLITECPP_INSTALL)
+    include(GNUInstallDirs)
+    install(TARGETS sqlite3
+        EXPORT ${PROJECT_NAME}Targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT libraries)
+    install(FILES sqlite3.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT headers)
+endif(SQLITECPP_INSTALL)


### PR DESCRIPTION
Hi:
First of all I want to say thanks for your library. It's pretty useful with elegant API design. I have encountered some issues when using this lib so I made this MR.
Currently I'm using a cmake based build system and trying to add `SQLiteCpp` into my project. Modern CMake has a lot of features to do that. like `add_subdirectory` or `FetchContent`. However both of them are not so good because of the install commands inside `SQLiteCpp`'s CMakeLists.txt. I don't want to install `SQLiteCpp` when invoking the install command after I build and install my projects. Some users, like me, may just want to static-link both `SQLiteCpp` and `sqlite3` internally. Besides, some users may just build `sqlite3` from source (`sqlite3` doesn't have an official cmake based build system as I know and that means they might write their own CMake scripts and create a `SQLite3` target, or even alias it as `SQLite::SQLite3`). So even if I set` SQLITECPP_INTERNAL_SQLITE` off, the install commands of `sqlite3` will cause a lot of CMake errors.
Hope this will be useful.