### PR TITLE
Add support for C++ Unicode types

### DIFF
--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -256,6 +256,83 @@ public:
      * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
      */
     void bind(const int aIndex, const char*         apValue);
+#ifdef __cpp_unicode_characters
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
+     *
+     * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
+     */
+    void bind(const int aIndex, const std::u16string& aValue);
+#if WCHAR_MAX == 0xffff
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
+     *
+     * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
+     */
+    void bind(const int aIndex, const std::wstring& aValue)
+    {
+#ifdef __cpp_lib_string_view
+        bind(aIndex, std::u16string_view(reinterpret_cast<const char16_t*>(aValue.data()), aValue.size()));
+#else
+        bind(aIndex, std::u16string(reinterpret_cast<const char16_t*>(aValue.data()), aValue.size()));
+#endif
+    }
+#endif
+#endif
+#ifdef __cpp_lib_string_view
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
+     *
+     * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
+     */
+    void bind(const int aIndex, const std::string_view aValue);
+#ifdef __cpp_char8_t
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
+     *
+     * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
+     */
+    void bind(const int aIndex, const std::u8string_view aValue)
+    {
+        bind(aIndex, std::string_view(reinterpret_cast<const char*>(aValue.data()), aValue.size()));
+    }
+#endif
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
+     *
+     * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
+     */
+    void bind(const int aIndex, const std::u16string_view aValue);
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
+     *
+     * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
+     */
+    void bind(const int aIndex, const char16_t* aValue)
+    {
+        bind(aIndex, std::u16string_view(aValue));
+    }
+#if WCHAR_MAX == 0xffff
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
+     *
+     * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
+     */
+    void bind(const int aIndex, const wchar_t* aValue)
+    {
+        bind(aIndex, std::u16string_view(reinterpret_cast<const char16_t*>(aValue)));
+    }
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
+     *
+     * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
+     */
+    void bind(const int aIndex, const std::wstring_view aValue)
+    {
+        bind(aIndex, std::u16string_view(reinterpret_cast<const char16_t*>(aValue.data()), aValue.size()));
+    }
+#endif
+#endif
     /**
      * @brief Bind a binary blob value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      *
@@ -278,6 +355,95 @@ public:
      * @warning Uses the SQLITE_STATIC flag, avoiding a copy of the data. The string must remains unchanged while executing the statement.
      */
     void bindNoCopy(const int aIndex, const char*           apValue);
+#ifdef __cpp_unicode_characters
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
+     *
+     * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
+     */
+    void bindNoCopy(const int aIndex, const std::u16string& aValue);
+#if WCHAR_MAX == 0xffff
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
+     *
+     * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
+     */
+    void bindNoCopy(const int aIndex, const std::wstring& aValue)
+    {
+#if __cpp_lib_string_view
+        bindNoCopy(aIndex, std::u16string_view(reinterpret_cast<const char16_t*>(aValue.data()), aValue.size()));
+#else
+        bindNoCopy(aIndex, std::u16string(reinterpret_cast<const char16_t*>(aValue.data()), aValue.size()));
+#endif
+    }
+#endif
+#endif
+#if __cpp_lib_string_view
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1).
+     *
+     * The string can contain null characters as it is binded using its size.
+     *
+     * @warning Uses the SQLITE_STATIC flag, avoiding a copy of the data. The string must remains unchanged while executing the statement.
+     */
+    void bindNoCopy(const int aIndex, const std::string_view aValue);
+#ifdef __cpp_char8_t
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1).
+     *
+     * The string can contain null characters as it is binded using its size.
+     *
+     * @warning Uses the SQLITE_STATIC flag, avoiding a copy of the data. The string must remains unchanged while executing the statement.
+     */
+    void bindNoCopy(const int aIndex, const std::u8string_view aValue)
+    {
+        bindNoCopy(aIndex, std::string_view(reinterpret_cast<const char*>(aValue.data()), aValue.size()));
+    }
+#endif
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1).
+     *
+     * The string can contain null characters as it is binded using its size.
+     *
+     * @warning Uses the SQLITE_STATIC flag, avoiding a copy of the data. The string must remains unchanged while executing the statement.
+     */
+    void bindNoCopy(const int aIndex, const std::u16string_view aValue);
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1).
+     *
+     * The string can contain null characters as it is binded using its size.
+     *
+     * @warning Uses the SQLITE_STATIC flag, avoiding a copy of the data. The string must remains unchanged while executing the statement.
+     */
+    void bindNoCopy(const int aIndex, const char16_t* aValue)
+    {
+        bindNoCopy(aIndex, std::u16string_view(aValue));
+    }
+#if WCHAR_MAX == 0xffff
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1).
+     *
+     * The string can contain null characters as it is binded using its size.
+     *
+     * @warning Uses the SQLITE_STATIC flag, avoiding a copy of the data. The string must remains unchanged while executing the statement.
+     */
+    void bindNoCopy(const int aIndex, const wchar_t* aValue)
+    {
+        bindNoCopy(aIndex, std::u16string_view(reinterpret_cast<const char16_t*>(aValue)));
+    }
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1).
+     *
+     * The string can contain null characters as it is binded using its size.
+     *
+     * @warning Uses the SQLITE_STATIC flag, avoiding a copy of the data. The string must remains unchanged while executing the statement.
+     */
+    void bindNoCopy(const int aIndex, const std::wstring_view aValue)
+    {
+        bindNoCopy(aIndex, std::u16string_view(reinterpret_cast<const char16_t*>(aValue.data()), aValue.size()));
+    }
+#endif
+#endif
     /**
      * @brief Bind a binary blob value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      *
@@ -290,6 +456,28 @@ public:
      * @see clearBindings() to set all bound parameters to NULL.
      */
     void bind(const int aIndex);
+
+    template<typename T>
+    inline void bind(const char* apName, T&& aValue)
+    {
+        bind(getIndex(apName), std::forward<T>(aValue));
+    }
+    template<typename T>
+    inline void bindNoCopy(const char* apName, T&& aValue)
+    {
+        bindNoCopy(getIndex(apName), std::forward<T>(aValue));
+    }
+    template<typename T>
+    inline void bind(const std::string& aName, T&& aValue)
+    {
+        bind(getIndex(aName.c_str()), std::forward<T>(aValue));
+    }
+    template<typename T>
+    inline void bindNoCopy(const std::string& aName, T&& aValue)
+    {
+        bindNoCopy(getIndex(aName.c_str()), std::forward<T>(aValue));
+    }
+
 
     /**
      * @brief Bind an int value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)

--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <map>
 #include <memory>
+#include <cstdint>
 
 // Forward declarations to avoid inclusion of <sqlite3.h> in a header
 struct sqlite3;
@@ -73,6 +74,110 @@ public:
     Statement(const Database& aDatabase, const std::string& aQuery) :
         Statement(aDatabase, aQuery.c_str())
     {}
+
+#ifdef __cpp_unicode_characters
+    /**
+     * @brief Compile and register the SQL query for the provided SQLite Database Connection
+     *
+     * @param[in] aDatabase the SQLite Database Connection
+     * @param[in] aQuery    an UTF-16 encoded query string
+     *
+     * Exception is thrown in case of error, then the Statement object is NOT constructed.
+     */
+    Statement(const Database& aDatabase, const std::u16string& aQuery);
+
+#if WCHAR_MAX == 0xffff
+    /**
+     * @brief Compile and register the SQL query for the provided SQLite Database Connection
+     *
+     * @param[in] aDatabase the SQLite Database Connection
+     * @param[in] aQuery    an UTF-16 encoded query string
+     *
+     * Exception is thrown in case of error, then the Statement object is NOT constructed.
+     */
+    Statement(const Database& aDatabase, const std::wstring& aQuery) :
+#ifdef __cpp_lib_string_view
+        Statement(aDatabase, std::u16string_view(reinterpret_cast<const char16_t*>(aQuery.data()), aQuery.size()))
+#else
+        Statement(aDatabase, std::u16string(reinterpret_cast<const char16_t*>(aQuery.data()), aQuery.size()))
+#endif
+    {}
+#endif  // WCHAR_MAX == 0xffff
+#endif  // __cpp_unicode_characters
+
+#ifdef __cpp_lib_string_view
+    /**
+     * @brief Compile and register the SQL query for the provided SQLite Database Connection
+     *
+     * @param[in] aDatabase the SQLite Database Connection
+     * @param[in] aQuery    an UTF-16 encoded query string
+     *
+     * Exception is thrown in case of error, then the Statement object is NOT constructed.
+     */
+    Statement(const Database& aDatabase, const std::string_view aQuery);
+
+#ifdef __cpp_char8_t
+    /**
+     * @brief Compile and register the SQL query for the provided SQLite Database Connection
+     *
+     * @param[in] aDatabase the SQLite Database Connection
+     * @param[in] aQuery    an UTF-8 encoded query string
+     *
+     * Exception is thrown in case of error, then the Statement object is NOT constructed.
+     */
+    Statement(const Database& aDatabase, const std::u8string_view aQuery) :
+        Statement(aDatabase, std::string_view(reinterpret_cast<const char*>(aQuery.data()), aQuery.size()))
+    {}
+#endif  // __cpp_char8_t
+
+    /**
+     * @brief Compile and register the SQL query for the provided SQLite Database Connection
+     *
+     * @param[in] aDatabase the SQLite Database Connection
+     * @param[in] apQuery   an UTF-16 encoded query string
+     *
+     * Exception is thrown in case of error, then the Statement object is NOT constructed.
+     */
+    Statement(const Database& aDatabase, const char16_t* apQuery) :
+        Statement(aDatabase, std::u16string_view(apQuery))
+    {}
+
+    /**
+     * @brief Compile and register the SQL query for the provided SQLite Database Connection
+     *
+     * @param[in] aDatabase the SQLite Database Connection
+     * @param[in] aQuery    an UTF-16 encoded query string
+     *
+     * Exception is thrown in case of error, then the Statement object is NOT constructed.
+     */
+    Statement(const Database& aDatabase, std::u16string_view aQuery);
+
+#if WCHAR_MAX == 0xffff
+    /**
+     * @brief Compile and register the SQL query for the provided SQLite Database Connection
+     *
+     * @param[in] aDatabase the SQLite Database Connection
+     * @param[in] apQuery   an UTF-16 encoded query string
+     *
+     * Exception is thrown in case of error, then the Statement object is NOT constructed.
+     */
+    Statement(const Database& aDatabase, const wchar_t* apQuery) :
+        Statement(aDatabase, std::u16string_view(reinterpret_cast<const char16_t*>(apQuery)))
+    {}
+
+    /**
+     * @brief Compile and register the SQL query for the provided SQLite Database Connection
+     *
+     * @param[in] aDatabase the SQLite Database Connection
+     * @param[in] aQuery   an UTF-16 encoded query string
+     *
+     * Exception is thrown in case of error, then the Statement object is NOT constructed.
+     */
+    Statement(const Database& aDatabase, const std::wstring_view aQuery) :
+        Statement(aDatabase, std::u16string_view(reinterpret_cast<const char16_t*>(aQuery.data()), aQuery.size()))
+    {}
+#endif  // WCHAR_MAX == 0xffff
+#endif  // __cpp_lib_string_view
 
     // Statement is non-copyable
     Statement(const Statement&) = delete;
@@ -689,6 +794,24 @@ private:
      * @return Shared pointer to prepared statement object
      */
     TStatementPtr prepareStatement();
+
+#ifdef __cpp_unicode_characters
+    /**
+     * @brief Prepare statement object.
+     *
+     * @return Shared pointer to prepared statement object
+     */
+    TStatementPtr prepareStatement(const std::u16string& query);
+#endif  // __cpp_unicode_characters
+
+#ifdef __cpp_lib_string_view
+    /**
+     * @brief Prepare statement object.
+     *
+     * @return Shared pointer to prepared statement object
+     */
+    TStatementPtr prepareStatement(const std::u16string_view query);
+#endif  // __cpp_lib_string_view
 
     /**
      * @brief Return a prepared statement object.

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -149,6 +149,31 @@ void Statement::bind(const int aIndex, const char* apValue)
     check(ret);
 }
 
+#ifdef __cpp_unicode_characters
+void Statement::bind(const int aIndex, const std::u16string& aValue)
+{
+    const int ret = sqlite3_bind_text16(getPreparedStatement(), aIndex, aValue.data(),
+                                        static_cast<int>(aValue.size() * sizeof(char16_t)), SQLITE_TRANSIENT);
+    check(ret);
+}
+#endif
+
+#ifdef __cpp_lib_string_view
+void Statement::bind(const int aIndex, const std::string_view aValue)
+{
+    const int ret = sqlite3_bind_text(getPreparedStatement(), aIndex, aValue.data(),
+                                      static_cast<int>(aValue.size()), SQLITE_TRANSIENT);
+    check(ret);
+}
+
+void Statement::bind(const int aIndex, const std::u16string_view aValue)
+{
+    const int ret = sqlite3_bind_text16(getPreparedStatement(), aIndex, aValue.data(),
+                                        static_cast<int>(aValue.size() * sizeof(char16_t)), SQLITE_TRANSIENT);
+    check(ret);
+}
+#endif
+
 // Bind a binary blob value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bind(const int aIndex, const void* apValue, const int aSize)
 {
@@ -170,6 +195,31 @@ void Statement::bindNoCopy(const int aIndex, const char* apValue)
     const int ret = sqlite3_bind_text(getPreparedStatement(), aIndex, apValue, -1, SQLITE_STATIC);
     check(ret);
 }
+
+#ifdef __cpp_unicode_characters
+void Statement::bindNoCopy(const int aIndex, const std::u16string& aValue)
+{
+    const int ret = sqlite3_bind_text16(getPreparedStatement(), aIndex, aValue.data(),
+                                        static_cast<int>(aValue.size() * sizeof(char16_t)), SQLITE_STATIC);
+    check(ret);
+}
+#endif
+
+#ifdef __cpp_lib_string_view
+void Statement::bindNoCopy(const int aIndex, const std::string_view aValue)
+{
+    const int ret = sqlite3_bind_text(getPreparedStatement(), aIndex, aValue.data(),
+                                      static_cast<int>(aValue.size()), SQLITE_STATIC);
+    check(ret);
+}
+
+void Statement::bindNoCopy(const int aIndex, const std::u16string_view aValue)
+{
+    const int ret = sqlite3_bind_text16(getPreparedStatement(), aIndex, aValue.data(),
+                                        static_cast<int>(aValue.size() * sizeof(char16_t)), SQLITE_STATIC);
+    check(ret);
+}
+#endif
 
 // Bind a binary blob value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bindNoCopy(const int aIndex, const void* apValue, const int aSize)

--- a/tests/Column_test.cpp
+++ b/tests/Column_test.cpp
@@ -197,6 +197,59 @@ static void test_column_basis(bool utf16)
         const SQLite::Column dbl = query.getColumn(3);
         EXPECT_EQ(0.123, dbl.getDouble());
     }
+
+#ifdef __cpp_unicode_characters
+    query.reset();
+    query.executeStep();
+
+    {
+        const auto first_u16 = u"first";
+
+        const std::u16string    str16 = query.getColumn(1);
+        const char16_t *        txt16 = query.getColumn(1);
+
+        EXPECT_EQ(5, str16.length());
+        EXPECT_EQ(10, query.getColumn(1).getBytes16());
+        EXPECT_EQ(0, memcmp(first_u16, str16.data(), str16.length() * sizeof(char16_t)));
+        EXPECT_EQ(5, std::char_traits<char16_t>::length(txt16));
+        EXPECT_EQ(0, std::char_traits<char16_t>::compare(first_u16, txt16, 6));
+    }
+
+#if WCHAR_MAX == 0xffff
+    query.reset();
+    query.executeStep();
+
+    {
+        const auto first_w = L"first";
+
+        const std::wstring      wstr = query.getColumn(1);
+        const wchar_t*          wtxt = query.getColumn(1);
+
+        EXPECT_EQ(5, wstr.length());
+        EXPECT_EQ(0, memcmp(first_w, wstr.data(), wstr.length() * sizeof(wchar_t)));
+        EXPECT_EQ(5, std::char_traits<wchar_t>::length(wtxt));
+        EXPECT_EQ(0, std::char_traits<wchar_t>::compare(first_w, wtxt, 6));
+    }
+#endif  // WCHAR_MAX == 0xffff
+
+#endif  // __cpp_unicode_characters
+
+#ifdef __cpp_char8_t
+    query.reset();
+    query.executeStep();
+
+    {
+        const auto first_u8 = u8"first";
+
+        const std::u8string     str8 = query.getColumn(1);
+        const char8_t*          txt8 = query.getColumn(1);
+
+        EXPECT_EQ(5, str8.length());
+        EXPECT_EQ(0, memcmp(first_u8, str8.data(), str8.length() * sizeof(char8_t)));
+        EXPECT_EQ(5, std::char_traits<char8_t>::length(txt8));
+        EXPECT_EQ(0, std::char_traits<char8_t>::compare(first_u8, txt8, 6));
+    }
+#endif  // __cpp_char8_t
 }
 
 TEST(Column, basis)

--- a/tests/Statement_test.cpp
+++ b/tests/Statement_test.cpp
@@ -138,6 +138,7 @@ TEST(Statement, moveConstructor)
     // Moved statements should throw
     EXPECT_THROW(query.getColumnIndex("value"), SQLite::Exception);
     EXPECT_THROW(query.getColumn(index), SQLite::Exception);
+    EXPECT_THROW(query.getExpandedSQL(), SQLite::Exception);
 }
 
 #endif
@@ -309,6 +310,7 @@ TEST(Statement, bindings)
         insert.bind(3, dbl);
         EXPECT_EQ(insert.getExpandedSQL(), "INSERT INTO test VALUES (NULL, 'first', -123, 0.123)");
         EXPECT_EQ(1, insert.exec());
+        EXPECT_EQ(1, insert.getChanges());
         EXPECT_EQ(SQLITE_DONE, db.getErrorCode());
 
         // Check the result

--- a/tests/Statement_test.cpp
+++ b/tests/Statement_test.cpp
@@ -142,6 +142,45 @@ TEST(Statement, moveConstructor)
 
 #endif
 
+#ifdef __cpp_unicode_characters
+TEST(Statement, unicode)
+{
+    // Create a new database
+    SQLite::Database db(":memory:", SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
+    EXPECT_EQ(0, db.exec("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)"));
+
+    const std::string sql("SELECT * FROM test");
+    const std::u16string sql_u16(u"SELECT * FROM test");
+
+    SQLite::Statement query_u16_char(db, sql_u16.c_str());
+    EXPECT_EQ(sql, query_u16_char.getQuery());
+
+    SQLite::Statement query_u16_str(db, sql_u16);
+    EXPECT_EQ(sql, query_u16_str.getQuery());
+
+    EXPECT_THROW(SQLite::Statement(db, u"SELECT * FROM test2"), SQLite::Exception);
+
+#if WCHAR_MAX == 0xffff
+    const std::wstring sql_w(L"SELECT * FROM test");
+
+    SQLite::Statement query_w_char(db, sql_w.c_str());
+    EXPECT_EQ(sql, query_w_char.getQuery());
+    SQLite::Statement query_w_str(db, sql_w);
+    EXPECT_EQ(sql, query_w_str.getQuery());
+#endif
+
+#ifdef __cpp_char8_t
+    const std::u8string sql_u8(u8"SELECT * FROM test");
+
+    SQLite::Statement query_u8_char(db, sql_u8.c_str());
+    EXPECT_EQ(sql, query_u8_char.getQuery());
+    SQLite::Statement query_u8_str(db, sql_u8);
+    EXPECT_EQ(sql, query_u8_str.getQuery());
+    EXPECT_THROW(SQLite::Statement(db, u8"SELECT * FROM test2"), SQLite::Exception);
+#endif
+}
+#endif
+
 TEST(Statement, executeStep)
 {
     // Create a new database


### PR DESCRIPTION
Add support for using char8_t, char16_t, wchar_t, u8string, u16string & wstring when available.
wchar_t & wstring support are only available on platforms with a 2 byte wchar_t.

Usable to create Statements, bind parameters and retrieve column data.

The first commit is a fix for when the native database is in UTF-16 format and you try to extract a std::string.
