### PR TITLE
Ensure that TEXT column is UTF-8 encoded before using sqlite3_column_blob()

### DIFF
--- a/src/Column.cpp
+++ b/src/Column.cpp
@@ -92,6 +92,9 @@ std::string Column::getString() const
 {
     // Note: using sqlite3_column_blob and not sqlite3_column_text
     // - no need for sqlite3_column_text to add a \0 on the end, as we're getting the bytes length directly
+    //   however, we need to call sqlite3_column_bytes() to ensure correct format. It's a noop on a BLOB
+    //   or a TEXT value with the correct encoding (UTF-8). Otherwise it'll do a conversion to TEXT (UTF-8).
+    (void)sqlite3_column_bytes(mStmtPtr.get(), mIndex);
     auto data = static_cast<const char *>(sqlite3_column_blob(mStmtPtr.get(), mIndex));
 
     // SQLite docs: "The safest policy is to invoke… sqlite3_column_blob() followed by sqlite3_column_bytes()"


### PR DESCRIPTION
If the database is in a different format (ie. UTF-16) the memory that sqlite3_column_blob() will point to by default will be the native (UTF-16) encoding. Calling sqlite3_column_bytes() will basically be a noop for a BLOB or a TEXT already in UTF-8. Otherwise it'll convert to TEXT w/UTF-8.

Run the 'basis' tests against both a UTF-8 and a UTF-16 database. Reset & rerun query between tests blocks to reset column types. Reorder a few getText()/getString() operations to ensure we test both ordering. Don't try to convert random blob to TEXT. Will fail encoding conversion.

Extracted from https://github.com/SRombauts/SQLiteCpp/pull/379 by @dougnazar