### PR TITLE
make std::filesystem optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,6 +294,13 @@ else (SQLITECPP_INTERNAL_SQLITE)
     endif()
 endif (SQLITECPP_INTERNAL_SQLITE)
 
+## disable the optional support for std::filesystem (C++17)
+option(SQLITECPP_DISABLE_STD_FILESYSTEM "Disable the use of std::filesystem in SQLiteCpp." OFF)
+if (SQLITECPP_DISABLE_STD_FILESYSTEM)
+    message (STATUS "Disabling std::filesystem support")
+    add_definitions(-DSQLITECPP_DISABLE_STD_FILESYSTEM)
+endif (SQLITECPP_DISABLE_STD_FILESYSTEM)
+
 # Link target with pthread and dl for Unix
 if (UNIX)
     set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -33,6 +33,22 @@ __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
     #define SQLITECPP_HAVE_STD_FILESYSTEM
 #endif
 
+// disable the support if the required header is not available
+#ifdef __has_include
+    #ifndef __has_include(<filesystem>)
+        #undef SQLITECPP_HAVE_STD_FILESYSTEM
+    #endif
+    #ifndef __has_include(<experimental/filesystem>)
+        #undef SQLITECPP_HAVE_EXPERIMENTAL_FILESYSTEM
+    #endif
+#endif
+
+// C++17 allow to disable std::filesystem support
+#ifdef SQLITECPP_DISABLE_STD_FILESYSTEM
+    #undef SQLITECPP_HAVE_STD_FILESYSTEM
+    #undef SQLITECPP_HAVE_STD_EXPERIMENTAL_FILESYSTEM
+#endif
+
 #ifdef SQLITECPP_HAVE_STD_FILESYSTEM
 #include  <filesystem>
 #endif // c++17 and a suitable compiler

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,11 @@ unix_like_code = '''
 '''
 unix_like = cxx.compiles(unix_like_code, name : 'unix like environment')
 
+## C++17 disable the support for std::filesystem (by default off)
+if get_option('SQLITECPP_DISABLE_STD_FILESYSTEM')
+    sqlitecpp_cxx_flags += ['-DSQLITECPP_DISABLE_STD_FILESYSTEM']
+endif
+
 thread_dep = dependency('threads')
 # sqlite3 support
 sqlite3_dep = dependency(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -9,6 +9,8 @@ option('SQLITE_ENABLE_ASSERT_HANDLER', type: 'boolean', value: false, descriptio
 option('SQLITE_HAS_CODEC', type: 'boolean', value: false, description: 'Enable database encryption API. Not available in the public release of SQLite.')
 ## Force forward declaration of legacy struct sqlite3_value (pre SQLite 3.19)
 option('SQLITE_USE_LEGACY_STRUCT', type: 'boolean', value: false, description: 'Fallback to forward declaration of legacy struct sqlite3_value (pre SQLite 3.19)')
+## Disable the support for std::filesystem (C++17)
+option('SQLITECPP_DISABLE_STD_FILESYSTEM', type: 'boolean', value: false, description: 'Disable the support for std::filesystem (C++17)')
 ## Enable build for the tests of SQLiteC++
 option('SQLITECPP_BUILD_TESTS', type: 'boolean', value: false, description: 'Build SQLiteC++ unit tests.')
 ## Build the examples of SQLiteC++


### PR DESCRIPTION
## Description
Add a switch to disable `std::filesystem` so it can be disabled if required on older compilers, this should let users that older compilers versions to disable it, solving #378 for meson and cmake, additionally checks in the source code if the header is found

## changes
- CMakeLists.txt: adds a new option that is disabled by default
- Database.h
  -  adds an additional check for `<filesystem>` and `<experimental/filesystem>`
  - checks for the previous switch and disables the support if enabled
- `meson.build`/`meson.options` adds the same option that disables `std::filesystem` support

I think this PR should be made on `3.2.1` or greater as is a new feature/enhancement itself and should come with the other planned project cleanups, please let me know if there is anything else required

