### PR TITLE
[meson] add missing compile options

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,10 +20,14 @@ unix_like_code = '''
 '''
 unix_like = cxx.compiles(unix_like_code, name : 'unix like environment')
 
-## C++17 disable the support for std::filesystem (by default off)
-if get_option('SQLITECPP_DISABLE_STD_FILESYSTEM')
-    sqlitecpp_cxx_flags += ['-DSQLITECPP_DISABLE_STD_FILESYSTEM']
-endif
+mingw_64_env_code = '''
+    #if defined(__MINGW64__)
+    // do nothing
+    #else
+    # error "Non MinGW-W64 environment"
+    #endif
+'''
+mingw_64_env = cxx.compiles(mingw_64_env_code, name : 'MinGW-W64 environment')
 
 thread_dep = dependency('threads')
 # sqlite3 support
@@ -129,6 +133,29 @@ if get_option('SQLITE_USE_LEGACY_STRUCT')
         '-DSQLITE_USE_LEGACY_STRUCT',
     ] 
 endif
+
+## C++17 disable the support for std::filesystem (by default off)
+if get_option('SQLITECPP_DISABLE_STD_FILESYSTEM')
+    sqlitecpp_cxx_flags += ['-DSQLITECPP_DISABLE_STD_FILESYSTEM']
+endif
+
+## stack protection hardening
+if get_option('SQLITECPP_USE_STACK_PROTECTOR')
+    ## if is on MinGW-W64 give a warning that is not supported
+    if mingw_64_env
+        warning('SQLiteCpp does not support stack protection on MinGW-W64')
+        warming('this could lead to a crash on the application')
+        warming('you can disable this warning by setting SQLITECPP_USE_STACK_PROTECTOR to false')
+    else
+        sqlitecpp_args += ['-fstack-protector']
+    endif
+endif
+
+## enable ommit load extension
+if get_option('SQLITECPP_OMIT_LOAD_EXTENSION')
+    sqlitecpp_args += ['-DSQLITE_OMIT_LOAD_EXTENSION']
+endif
+
 
 if unix_like
     sqlitecpp_args += [

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -9,8 +9,12 @@ option('SQLITE_ENABLE_ASSERT_HANDLER', type: 'boolean', value: false, descriptio
 option('SQLITE_HAS_CODEC', type: 'boolean', value: false, description: 'Enable database encryption API. Not available in the public release of SQLite.')
 ## Force forward declaration of legacy struct sqlite3_value (pre SQLite 3.19)
 option('SQLITE_USE_LEGACY_STRUCT', type: 'boolean', value: false, description: 'Fallback to forward declaration of legacy struct sqlite3_value (pre SQLite 3.19)')
+## Enable ommit load extension
+option('SQLITE_OMMIT_LOAD_EXTENSION', type: 'boolean', value: false, description: 'Enable ommit load extension.')
 ## Disable the support for std::filesystem (C++17)
 option('SQLITECPP_DISABLE_STD_FILESYSTEM', type: 'boolean', value: false, description: 'Disable the support for std::filesystem (C++17)')
+## Stack protection is not supported on MinGW-W64 on Windows, allow this flag to be turned off.
+option('SQLITECPP_USE_STACK_PROTECTION', type: 'boolean', value: true, description: 'Disable stack protection on MinGW-W64 on Windows.')
 ## Enable build for the tests of SQLiteC++
 option('SQLITECPP_BUILD_TESTS', type: 'boolean', value: false, description: 'Build SQLiteC++ unit tests.')
 ## Build the examples of SQLiteC++

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,7 +14,7 @@ option('SQLITE_OMMIT_LOAD_EXTENSION', type: 'boolean', value: false, description
 ## Disable the support for std::filesystem (C++17)
 option('SQLITECPP_DISABLE_STD_FILESYSTEM', type: 'boolean', value: false, description: 'Disable the support for std::filesystem (C++17)')
 ## Stack protection is not supported on MinGW-W64 on Windows, allow this flag to be turned off.
-option('SQLITECPP_USE_STACK_PROTECTION', type: 'boolean', value: true, description: 'Disable stack protection on MinGW-W64 on Windows.')
+option('SQLITECPP_USE_STACK_PROTECTION', type: 'boolean', value: true, description: 'Enable stack protection for MySQL.')
 ## Enable build for the tests of SQLiteC++
 option('SQLITECPP_BUILD_TESTS', type: 'boolean', value: false, description: 'Build SQLiteC++ unit tests.')
 ## Build the examples of SQLiteC++


### PR DESCRIPTION
## description

as the name implies this PR adds the missing `SQLITECPP_USE_STACK_PROTECTOR` and `SQLITECPP_OMIT_LOAD_EXTENSION` that were available in CMake but not in meson additionally adds the special check for `MinGW-W64` in order to not enable it and show a warning instead, solving a possible issue on meson related to #382 and #74