### PR TITLE
Fix preprocessor issues

### DIFF
--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -35,10 +35,10 @@ __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
 
 // disable the support if the required header is not available
 #ifdef __has_include
-    #ifndef __has_include(<filesystem>)
+    #if !__has_include(<filesystem>)
         #undef SQLITECPP_HAVE_STD_FILESYSTEM
     #endif
-    #ifndef __has_include(<experimental/filesystem>)
+    #if !__has_include(<experimental/filesystem>)
         #undef SQLITECPP_HAVE_EXPERIMENTAL_FILESYSTEM
     #endif
 #endif

--- a/tests/Database_test.cpp
+++ b/tests/Database_test.cpp
@@ -34,6 +34,7 @@ void assertion_failed(const char* apFile, const long apLine, const char* apFunc,
 }
 #endif
 
+#ifdef SQLITECPP_INTERNAL_SQLITE
 TEST(SQLiteCpp, version)
 {
     EXPECT_STREQ(SQLITE_VERSION,        SQLite::VERSION);
@@ -41,6 +42,7 @@ TEST(SQLiteCpp, version)
     EXPECT_STREQ(SQLITE_VERSION,        SQLite::getLibVersion());
     EXPECT_EQ   (SQLITE_VERSION_NUMBER, SQLite::getLibVersionNumber());
 }
+#endif
 
 TEST(Database, ctorExecCreateDropExist)
 {


### PR DESCRIPTION
- Do not compare the version number for external SQLite3 libraries
- Correct use of the __has_include macro to stop the preprocessor from complaining