### PR TITLE
add meson usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,62 @@ cmake --build .
 ctest --output-on-failure
 ```
 
+#### Building with meson
+
+You can build SQLiteCpp with [meson](https://mesonbuild.com/) using the provided meson project.
+
+you can install meson using pip: `pip install meson` however you may need to install ninja and other dependencies depending on your platform as an compiler toolchain
+
+Arch Linux:
+
+```sh
+# install clang (compiler toolchain) and ninja (recommended build system)
+sudo pacman -Syu clang ninja
+# install python and pip (required for meson)
+sudo pacman -Syu python python-pip
+# install meson 
+pip install meson
+```
+
+Ubuntu:
+
+```sh
+# install gcc(compiler toolchain) and ninja (recommended build system)
+sudo apt install build-essential ninja-build
+# install python and pip (required for meson)
+sudo apt install python3 python3-pip
+# install meson
+pip install meson
+```
+
+for example you can build the library using the default options with:
+
+```sh
+# setup the build directory
+meson setup builddir 
+# build sqlitecpp
+meson compile -C builddir
+```
+
+or if you wish to build with tests and examples:
+
+```sh
+# setup the build directory with tests and examples enabled
+meson setup builddir -DSQLITECPP_BUILD_TESTS=true -DSQLITECPP_BUILD_EXAMPLES=true
+# build sqlitecpp
+meson compile -C builddir
+```
+
+#### Using SQLiteCpp as subproject in meson
+
+please check the examples in the examples folder for usage of SQLiteCpp as a subproject in meson, as for the wrap file you can use the one provided in the subprojects folder called `SQLiteCpp.wrap`
+
+> keep in mind that even that this wrap should be up to date, it is recommended to check the latest version of SQLiteCpp and update the wrap file accordingly
+
+#### System SQLiteCpp support under meson
+
+additionally meson can detect and use the bundled sqlitecpp library included on your system if available, for example with vcpkg you would need to set the `PKG_CONFIG_PATH` environment variable to the vcpkg directory before running meson setup, and if applies the corresponding `PKG-CONFIG` executable to the path.
+
 #### Building the Doxygen/html documentation
 
 Make sure you have Dogygen installed and configure CMake using the `SQLITECPP_RUN_DOXYGEN=ON` flag:

--- a/examples/example1/meson.build
+++ b/examples/example1/meson.build
@@ -1,0 +1,20 @@
+
+
+sqlitecpp_dep = dependency(
+                'sqlitecpp_dep',
+                fallback: ['SQLiteCpp', 'sqlitecpp_dep']
+)
+
+example1_sources = files(
+    'main.cpp'
+)
+
+example1_dependencies = [
+    dependency('SQLite')
+]
+
+sqlitecpp_demo1_exe = executable('SQLITECPP_sample_demo1',
+                            sqlitecpp_sample1_srcs,
+                            dependencies: sqlitecpp_dep,
+                            # override the default options
+                            override_options: sqlitecpp_opts,)

--- a/examples/example1/meson.build
+++ b/examples/example1/meson.build
@@ -1,20 +1,20 @@
 
 
-sqlitecpp_dep = dependency(
-                'sqlitecpp_dep',
-                fallback: ['SQLiteCpp', 'sqlitecpp_dep']
-)
-
 example1_sources = files(
     'main.cpp'
 )
 
-example1_dependencies = [
-    dependency('SQLite')
-]
+example1_args = []
+
+## under windows define _CRT_SECURE_NO_WARNINGS
+if host_machine.system() == 'windows'
+    example1_args += ['-D_CRT_SECURE_NO_WARNINGS']
+endif
+
 
 sqlitecpp_demo1_exe = executable('SQLITECPP_sample_demo1',
                             sqlitecpp_sample1_srcs,
                             dependencies: sqlitecpp_dep,
-                            # override the default options
-                            override_options: sqlitecpp_opts,)
+                            # inherit the default options from sqlitecpp
+                            override_options: sqlitecpp_opts,
+                            cpp_args: example1_args,)

--- a/examples/example2/meson.build
+++ b/examples/example2/meson.build
@@ -1,20 +1,14 @@
-
-
-sqlitecpp_dep = dependency(
-                'sqlitecpp_dep',
-                fallback: ['SQLiteCpp', 'sqlitecpp_dep']
-)
-
-example1_sources = files(
+example2_srcs = files(
     'src/main.cpp'
 )
 
-example1_dependencies = [
-    dependency('SQLite')
-]
+# if running on windows define _CRT_SECURE_NO_WARNINGS
+example2_args = []
 
-sqlitecpp_demo1_exe = executable('SQLITECPP_sample_demo1',
-                            sqlitecpp_sample1_srcs,
+
+sqlitecpp_demo2_exe = executable('SQLITECPP_sample_demo1',
+                            sqlitecpp_sample2_srcs,
                             dependencies: sqlitecpp_dep,
-                            # override the default options
-                            override_options: sqlitecpp_opts,)
+                            # inherit the default options from sqlitecpp
+                            override_options: sqlitecpp_opts,
+                            cpp_args: example2_args)

--- a/examples/example2/meson.build
+++ b/examples/example2/meson.build
@@ -1,0 +1,20 @@
+
+
+sqlitecpp_dep = dependency(
+                'sqlitecpp_dep',
+                fallback: ['SQLiteCpp', 'sqlitecpp_dep']
+)
+
+example1_sources = files(
+    'src/main.cpp'
+)
+
+example1_dependencies = [
+    dependency('SQLite')
+]
+
+sqlitecpp_demo1_exe = executable('SQLITECPP_sample_demo1',
+                            sqlitecpp_sample1_srcs,
+                            dependencies: sqlitecpp_dep,
+                            # override the default options
+                            override_options: sqlitecpp_opts,)

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,0 +1,2 @@
+subdir('example1')
+subdir('example2')

--- a/meson.build
+++ b/meson.build
@@ -271,19 +271,7 @@ if get_option('SQLITECPP_BUILD_TESTS')
     test('sqlitecpp unit tests', testexe, args: test_args)
 endif
 if get_option('SQLITECPP_BUILD_EXAMPLES')
-    ## demo 1 executable
-    sqlitecpp_demo1_exe = executable('SQLITECPP_sample_demo1',
-                            sqlitecpp_sample1_srcs,
-                            dependencies: sqlitecpp_dep,
-                            # override the default options
-                            override_options: sqlitecpp_opts,)
-    ## demo 2 executable
-    sqlitecpp_demo1_exe = executable('SQLITECPP_sample_demo2',
-                            sqlitecpp_sample2_srcs,
-                            dependencies: sqlitecpp_dep,
-                            # override the default options
-                            override_options: sqlitecpp_opts,)
-                    
+    subdir('examples')
 endif
 
 pkgconfig = import('pkgconfig')

--- a/subprojects/sqlitecpp.wrap
+++ b/subprojects/sqlitecpp.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = SQLiteCpp-3.2.1
+source_url = https://github.com/SRombauts/SQLiteCpp/archive/refs/tags/3.2.1.zip
+source_filename = sqlitecpp-3.2.1.zip
+source_hash = 584f7c36b6b169c10c890240ea5fb36318d0ea5713c908f08201a95a93642d21
+
+[provide]
+sqlitecpp = sqlitecpp_dep


### PR DESCRIPTION
## description

Draft for meson docs in the project readme an usage Guide, needs some cleanup and should come after #394 #391 so the examples and project work out of the box in OSX 11+ under meson

## changes
- [x] README.md
  -  [x] add build and installation guide for meson
- [x] examples/
   - [x] add a meson.build into examples directory (optional but preferred as the examples may grow in the future) 
   - [x] add example 1 meson.build > needs cleanup once OSX is building
   - [x] add example 2 meson.build > needs cleanup once OSX is building
   - [x] add an sqlitecpp.wrap example file (under the subprojects root folder of the project)
- [x] meson.build > needs to change the build of example to subdir 

> note: once meson support is mature enough it should be possible to add it on wrapdb and add a proper guide in the future