### PR TITLE
add disable option for sqlite3_expanded_sql

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,13 @@ if (SQLITECPP_DISABLE_STD_FILESYSTEM)
     add_definitions(-DSQLITECPP_DISABLE_STD_FILESYSTEM)
 endif (SQLITECPP_DISABLE_STD_FILESYSTEM)
 
+## disable the optional support for sqlite3_expanded_sql (from sqlite3 3.14.0)
+option(SQLITECPP_DISABLE_EXPANDED_SQL "Disable the use of sqlite3_expanded_sql in SQLiteCpp." OFF)
+if (SQLITECPP_DISABLE_EXPANDED_SQL)
+    message (STATUS "Disabling sqlite3_expanded_sql support")
+    add_definitions(-DSQLITECPP_DISABLE_EXPANDED_SQL)
+endif (SQLITECPP_DISABLE_EXPANDED_SQL)
+
 # Link target with pthread and dl for Unix
 if (UNIX)
     set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,7 @@ endif (SQLITECPP_DISABLE_STD_FILESYSTEM)
 option(SQLITECPP_DISABLE_EXPANDED_SQL "Disable the use of sqlite3_expanded_sql in SQLiteCpp." OFF)
 if (SQLITECPP_DISABLE_EXPANDED_SQL)
     message (STATUS "Disabling sqlite3_expanded_sql support")
-    add_definitions(-DSQLITECPP_DISABLE_EXPANDED_SQL)
+    target_compile_definitions(SQLiteCpp PUBLIC SQLITECPP_DISABLE_EXPANDED_SQL)
 endif (SQLITECPP_DISABLE_EXPANDED_SQL)
 
 # Link target with pthread and dl for Unix

--- a/meson.build
+++ b/meson.build
@@ -134,6 +134,14 @@ if get_option('SQLITECPP_DISABLE_STD_FILESYSTEM')
     sqlitecpp_cxx_flags += ['-DSQLITECPP_DISABLE_STD_FILESYSTEM']
 endif
 
+## get the user option for the SQLITECPP_DISABLE_SQLITE3_EXPANDED_SQL
+disable_sqlitecpp_expanded_sql = get_option('SQLITECPP_DISABLE_SQLITE3_EXPANDED_SQL')
+
+## Disable the use of sqlite3_expanded_sql (from sqlite3 3.14.0)
+if disable_sqlitecpp_expanded_sql
+    sqlitecpp_args += ['-DSQLITECPP_DISABLE_SQLITE3_EXPANDED_SQL']
+endif
+
 ## stack protection hardening
 if get_option('SQLITECPP_USE_STACK_PROTECTION')
     ## if is on MinGW-W64 give a warning that is not supported

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,6 +13,8 @@ option('SQLITE_USE_LEGACY_STRUCT', type: 'boolean', value: false, description: '
 option('SQLITE_OMIT_LOAD_EXTENSION', type: 'boolean', value: false, description: 'Enable ommit load extension.')
 ## Disable the support for std::filesystem (C++17)
 option('SQLITECPP_DISABLE_STD_FILESYSTEM', type: 'boolean', value: false, description: 'Disable the support for std::filesystem (C++17)')
+## Disable the support for sqlite3_expanded_sql (since SQLite 3.14.0)
+option('SQLITECPP_DISABLE_SQLITE3_EXPANDED_SQL', type: 'boolean', value: false, description: 'Disable the support for sqlite3_expanded_sql (since SQLite 3.14.0)')
 ## Stack protection is not supported on MinGW-W64 on Windows, allow this flag to be turned off.
 option('SQLITECPP_USE_STACK_PROTECTION', type: 'boolean', value: true, description: 'Enable stack protection for MySQL.')
 ## Enable build for the tests of SQLiteC++

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -17,6 +17,17 @@
 
 #include <sqlite3.h>
 
+// check for if SQLite3 version >= 3.14.0
+#if SQLITE_VERSION_NUMBER < 3014000
+    #warning "SQLite3 version is less than 3.14.0, so expanded SQL is not available"
+    #warning "To use expanded SQL, please upgrade to SQLite3 version 3.14.0 or later"
+    #warning "If you want to disable this warning, define SQLITECPP_DISABLE_SQLITE3_EXPANDED_SQL"
+    #warning "or use the specific project option in your build system"
+    #warning "disabling expanded SQL support"
+    #define SQLITECPP_DISABLE_SQLITE3_EXPANDED_SQL
+#endif
+
+
 namespace SQLite
 {
 
@@ -331,13 +342,19 @@ const char* Statement::getErrorMsg() const noexcept
     return sqlite3_errmsg(mpSQLite);
 }
 
+
 // Return a UTF-8 string containing the SQL text of prepared statement with bound parameters expanded.
 std::string Statement::getExpandedSQL() const {
+    #ifdef SQLITECPP_DISABLE_SQLITE3_EXPANDED_SQL
+    throw SQLite::Exception("this version of SQLiteCpp does not support expanded SQL");
+    #else
     char* expanded = sqlite3_expanded_sql(getPreparedStatement());
     std::string expandedString(expanded);
     sqlite3_free(expanded);
     return expandedString;
+    #endif
 }
+
 
 // Prepare SQLite statement object and return shared pointer to this object
 Statement::TStatementPtr Statement::prepareStatement()


### PR DESCRIPTION
## Description
Add an option to disable `sqlite3_expanded_sql` that disables the internal use of it inside the method `Statement::getExpandedSQL` so it gives a warning when building SQLiteCpp, at runtime it will give an exception instead

this should fix #213

## changes
- CMakeLists.txt: add the `SQLITECPP_DISABLE_EXPANDED_SQL` option along with the define `SQLITECPP_DISABLE_EXPANDED_SQL`
- meson.build/meson.options: add the same  `SQLITECPP_DISABLE_EXPANDED_SQL`  that defines `SQLITECPP_DISABLE_EXPANDED_SQL`
- Statement.cpp
  - give a warning at compile time if  `SQLITECPP_DISABLE_EXPANDED_SQL` is not defined when running the version of sqlite < 3.14.0
  - give an exception when trying to run `Statement::getExpandedSQL` if compiled witouth support for `sqlite3_expanded_sql`