### PR TITLE
Lint corrections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,7 @@ endif (SQLITECPP_INTERNAL_SQLITE)
 option(SQLITECPP_DISABLE_STD_FILESYSTEM "Disable the use of std::filesystem in SQLiteCpp." OFF)
 if (SQLITECPP_DISABLE_STD_FILESYSTEM)
     message (STATUS "Disabling std::filesystem support")
-    add_definitions(-DSQLITECPP_DISABLE_STD_FILESYSTEM)
+    target_compile_definitions(SQLiteCpp PUBLIC SQLITECPP_DISABLE_STD_FILESYSTEM)
 endif (SQLITECPP_DISABLE_STD_FILESYSTEM)
 
 # Link target with pthread and dl for Unix

--- a/meson.build
+++ b/meson.build
@@ -119,7 +119,7 @@ endif
 
 if get_option('SQLITE_HAS_CODEC')
     sqlitecpp_args += [
-        'SQLITE_HAS_CODEC',
+        '-DSQLITE_HAS_CODEC',
     ]
 endif
 


### PR DESCRIPTION
## Description
make simple corrections in both build systems (Meson/CMake)
- remove the use of `add_definitions` for `std::filesystem` support in CMake
- fix the definition of `SQLITE_HAS_CODEC` in Meson