### PR TITLE
use checkout@v3 in CMake CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           }
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: submodule
       run: git submodule update --init --recursive
     - name: extra_path

--- a/.github/workflows/subdir_example.yml
+++ b/.github/workflows/subdir_example.yml
@@ -27,7 +27,7 @@ jobs:
           }
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: configure
       shell: cmake -P {0}
       run: |


### PR DESCRIPTION
There is a warning due to the usage of checkout@V2 that can be fixed by using V3 instead.