### PR TITLE
Fix compiler warnings warning

### DIFF
--- a/include/SQLiteCpp/SQLiteCppExport.h
+++ b/include/SQLiteCpp/SQLiteCppExport.h
@@ -21,10 +21,8 @@
 #if defined(_WIN32)&& !defined(__GNUC__) && defined(SQLITECPP_COMPILE_DLL)
     #if SQLITECPP_DLL_EXPORT
         #define SQLITECPP_API __declspec(dllexport)
-        #pragma message("Exporting symbols")
     #else
         #define SQLITECPP_API __declspec(dllimport)
-        #pragma message("Importing symbols")
     #endif    
 #else    
     #if __GNUC__ >= 4

--- a/meson.build
+++ b/meson.build
@@ -148,8 +148,14 @@ if get_option('SQLITECPP_USE_STACK_PROTECTION')
         message('warning: SQLiteCpp does not support stack protection on MinGW-W64')
         message('warning: this could lead to a crash on the application')
         message('warning: you can disable this warning by setting SQLITECPP_USE_STACK_PROTECTOR to false')
-    else
+    ## check if it is supported by the compiler
+    elif cxx.has_argument('-fstack-protector')
         sqlitecpp_args += ['-fstack-protector']
+    ## if not supported give a warning
+    else
+        message('warning: SQLiteCpp does not have stack protection support in this compiler')
+        message('warning: this argument will be ignored')
+        message('warning: you can disable this warning by setting SQLITECPP_USE_STACK_PROTECTOR to false')
     endif
 endif
 

--- a/src/Column.cpp
+++ b/src/Column.cpp
@@ -18,11 +18,11 @@
 namespace SQLite
 {
 
-SQLITECPP_API const int INTEGER   = SQLITE_INTEGER;
-SQLITECPP_API const int FLOAT     = SQLITE_FLOAT;
-SQLITECPP_API const int TEXT      = SQLITE_TEXT;
-SQLITECPP_API const int BLOB      = SQLITE_BLOB;
-SQLITECPP_API const int Null      = SQLITE_NULL;
+const int INTEGER   = SQLITE_INTEGER;
+const int FLOAT     = SQLITE_FLOAT;
+const int TEXT      = SQLITE_TEXT;
+const int BLOB      = SQLITE_BLOB;
+const int Null      = SQLITE_NULL;
 
 
 // Encapsulation of a Column in a row of the result pointed by the prepared Statement.

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -26,25 +26,25 @@
 namespace SQLite
 {
 
-SQLITECPP_API const int   OK                = SQLITE_OK;
-SQLITECPP_API const int   OPEN_READONLY     = SQLITE_OPEN_READONLY;
-SQLITECPP_API const int   OPEN_READWRITE    = SQLITE_OPEN_READWRITE;
-SQLITECPP_API const int   OPEN_CREATE       = SQLITE_OPEN_CREATE;
-SQLITECPP_API const int   OPEN_URI          = SQLITE_OPEN_URI;
-SQLITECPP_API const int   OPEN_MEMORY       = SQLITE_OPEN_MEMORY;
-SQLITECPP_API const int   OPEN_NOMUTEX      = SQLITE_OPEN_NOMUTEX;
-SQLITECPP_API const int   OPEN_FULLMUTEX    = SQLITE_OPEN_FULLMUTEX;
-SQLITECPP_API const int   OPEN_SHAREDCACHE  = SQLITE_OPEN_SHAREDCACHE;
-SQLITECPP_API const int   OPEN_PRIVATECACHE = SQLITE_OPEN_PRIVATECACHE;
+const int   OK                = SQLITE_OK;
+const int   OPEN_READONLY     = SQLITE_OPEN_READONLY;
+const int   OPEN_READWRITE    = SQLITE_OPEN_READWRITE;
+const int   OPEN_CREATE       = SQLITE_OPEN_CREATE;
+const int   OPEN_URI          = SQLITE_OPEN_URI;
+const int   OPEN_MEMORY       = SQLITE_OPEN_MEMORY;
+const int   OPEN_NOMUTEX      = SQLITE_OPEN_NOMUTEX;
+const int   OPEN_FULLMUTEX    = SQLITE_OPEN_FULLMUTEX;
+const int   OPEN_SHAREDCACHE  = SQLITE_OPEN_SHAREDCACHE;
+const int   OPEN_PRIVATECACHE = SQLITE_OPEN_PRIVATECACHE;
 // check if sqlite version is >= 3.31.0 and SQLITE_OPEN_NOFOLLOW is defined
 #if SQLITE_VERSION_NUMBER >= 3031000 && defined(SQLITE_OPEN_NOFOLLOW)
-SQLITECPP_API const int   OPEN_NOFOLLOW     = SQLITE_OPEN_NOFOLLOW;
+const int   OPEN_NOFOLLOW     = SQLITE_OPEN_NOFOLLOW;
 #else
-SQLITECPP_API const int   OPEN_NOFOLLOW     = 0;
+const int   OPEN_NOFOLLOW     = 0;
 #endif
 
-SQLITECPP_API const char* const VERSION        = SQLITE_VERSION;
-SQLITECPP_API const int         VERSION_NUMBER = SQLITE_VERSION_NUMBER;
+const char* const VERSION        = SQLITE_VERSION;
+const int         VERSION_NUMBER = SQLITE_VERSION_NUMBER;
 
 // Return SQLite version string using runtime call to the compiled library
 const char* getLibVersion() noexcept


### PR DESCRIPTION
# Fix several compiler warnings

fixed several warnings that come from #406, most of the warnings are not harmful but it is better to fix them
- removed the  `#pragma message` inside `SQLiteCppExport.h`  as it showed as a warning
- removed `SQLITECPP_API` inside cpp files as it will be ignored and show a warning instead
- [meson only] check if stack protection is supported before adding the flag for it

this should fix #412 