### PR TITLE
Add CMake option SQLITE_ENABLE_DBSTAT_VTAB and SQLITE_ENABLE_RTREE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,7 +252,6 @@ endif ()
 option(SQLITECPP_INTERNAL_SQLITE "Add the internal SQLite3 source to the project." ON)
 if (SQLITECPP_INTERNAL_SQLITE)
     message(STATUS "Compile sqlite3 from source in subdirectory")
-    option(SQLITE_ENABLE_JSON1 "Enable JSON1 extension when building internal sqlite3 library." ON)
     option(SQLITE_ENABLE_RTREE "Enable RTree extension when building internal sqlite3 library." OFF)
     # build the SQLite3 C library (for ease of use/compatibility) versus Linux sqlite3-dev package
     add_subdirectory(sqlite3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,7 @@ option(SQLITECPP_INTERNAL_SQLITE "Add the internal SQLite3 source to the project
 if (SQLITECPP_INTERNAL_SQLITE)
     message(STATUS "Compile sqlite3 from source in subdirectory")
     option(SQLITE_ENABLE_JSON1 "Enable JSON1 extension when building internal sqlite3 library." ON)
+    option(SQLITE_ENABLE_RTREE "Enable RTree extension when building internal sqlite3 library." OFF)
     # build the SQLite3 C library (for ease of use/compatibility) versus Linux sqlite3-dev package
     add_subdirectory(sqlite3)
     target_link_libraries(SQLiteCpp PUBLIC SQLite::SQLite3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,7 @@ option(SQLITECPP_INTERNAL_SQLITE "Add the internal SQLite3 source to the project
 if (SQLITECPP_INTERNAL_SQLITE)
     message(STATUS "Compile sqlite3 from source in subdirectory")
     option(SQLITE_ENABLE_RTREE "Enable RTree extension when building internal sqlite3 library." OFF)
+    option(SQLITE_ENABLE_DBSTAT_VTAB "Enable DBSTAT read-only eponymous virtual table extension when building internal sqlite3 library." OFF)
     # build the SQLite3 C library (for ease of use/compatibility) versus Linux sqlite3-dev package
     add_subdirectory(sqlite3)
     target_link_libraries(SQLiteCpp PUBLIC SQLite::SQLite3)

--- a/sqlite3/CMakeLists.txt
+++ b/sqlite3/CMakeLists.txt
@@ -37,6 +37,13 @@ if (SQLITE_ENABLE_RTREE)
     message(STATUS "Compile sqlite3 with SQLITE_ENABLE_RTREE")
 endif (SQLITE_ENABLE_RTREE)
 
+if (SQLITE_ENABLE_DBSTAT_VTAB)
+    # Enable DBSTAT extension when building sqlite3
+    # See more here: https://www.sqlite.org/dbstat.html
+    target_compile_definitions(sqlite3 PUBLIC SQLITE_ENABLE_DBSTAT_VTAB)
+    message(STATUS "Compile sqlite3 with SQLITE_ENABLE_DBSTAT_VTAB")
+endif (SQLITE_ENABLE_DBSTAT_VTAB)
+
 if (UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))
     set_target_properties(sqlite3 PROPERTIES COMPILE_FLAGS "-fPIC")
 

--- a/sqlite3/CMakeLists.txt
+++ b/sqlite3/CMakeLists.txt
@@ -36,10 +36,11 @@ if (SQLITE_ENABLE_JSON1)
     target_compile_definitions(sqlite3 PUBLIC SQLITE_ENABLE_JSON1)
 endif (SQLITE_ENABLE_JSON1)
 
-if(SQLITE_ENABLE_RTREE)
+if (SQLITE_ENABLE_RTREE)
     # Enable RTree extension when building sqlite3
     # See more here: https://sqlite.org/rtree.html
     target_compile_definitions(sqlite3 PUBLIC SQLITE_ENABLE_RTREE)
+    message(STATUS "Compile sqlite3 with SQLITE_ENABLE_RTREE")
 endif (SQLITE_ENABLE_RTREE)
 
 if (UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))

--- a/sqlite3/CMakeLists.txt
+++ b/sqlite3/CMakeLists.txt
@@ -30,12 +30,6 @@ if (SQLITE_ENABLE_COLUMN_METADATA)
     target_compile_definitions(sqlite3 PUBLIC SQLITE_ENABLE_COLUMN_METADATA)
 endif (SQLITE_ENABLE_COLUMN_METADATA)
 
-if (SQLITE_ENABLE_JSON1)
-    # Enable JSON1 extension when building sqlite3
-    # See more here: https://www.sqlite.org/json1.html
-    target_compile_definitions(sqlite3 PUBLIC SQLITE_ENABLE_JSON1)
-endif (SQLITE_ENABLE_JSON1)
-
 if (SQLITE_ENABLE_RTREE)
     # Enable RTree extension when building sqlite3
     # See more here: https://sqlite.org/rtree.html


### PR DESCRIPTION
- Add CMake option SQLITE_ENABLE_RTREE to enable RTree extension when building internal sqlite3 library See more here: https://sqlite.org/rtree.html (Disabled by default)
- Remove option SQLITE_ENABLE_JSON1 since the JSON functions and operators are built into SQLite by default, as of SQLite version 3.38.0 (2022-02-22). see issue #425 SQLITE_ENABLE_JSON1 flag does not appear to compile sqlite3 with this option
- Add CMake option SQLITE_ENABLE_DBSTAT_VTAB to enable DBSTAT read-only eponymous virtual table extension when building internal sqlite3 library. See more here: https://www.sqlite.org/dbstat.html Fix #426 Support building SQLite with SQLITE_ENABLE_DBSTAT_VTAB compile option (Disabled by default)
