### PR TITLE
Add 6 Statement::bind() overrides using size_t for blobs

### DIFF
--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -156,6 +156,10 @@ public:
      * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
      */
     void bind(const int aIndex, const void*         apValue, const int aSize);
+    void bind(const int aIndex, const void*         apValue, const size_t aSize)
+    {
+        bind(aIndex, apValue, static_cast<int>(aSize));
+    }
     /**
      * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1).
      *
@@ -178,6 +182,10 @@ public:
      * @warning Uses the SQLITE_STATIC flag, avoiding a copy of the data. The string must remains unchanged while executing the statement.
      */
     void bindNoCopy(const int aIndex, const void*           apValue, const int aSize);
+    void bindNoCopy(const int aIndex, const void*           apValue, const size_t aSize)
+    {
+        bindNoCopy(aIndex, apValue, static_cast<int>(aSize));
+    }
     /**
      * @brief Bind a NULL value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      *
@@ -240,6 +248,10 @@ public:
     {
         bind(getIndex(apName), apValue, aSize);
     }
+    void bind(const char* apName, const void*           apValue, const size_t aSize)
+    {
+        bind(getIndex(apName), apValue, aSize);
+    }
     /**
      * @brief Bind a string value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      *
@@ -268,6 +280,10 @@ public:
      * @warning Uses the SQLITE_STATIC flag, avoiding a copy of the data. The string must remains unchanged while executing the statement.
      */
     void bindNoCopy(const char* apName, const void*         apValue, const int aSize)
+    {
+        bindNoCopy(getIndex(apName), apValue, aSize);
+    }
+    void bindNoCopy(const char* apName, const void*         apValue, const size_t aSize)
     {
         bindNoCopy(getIndex(apName), apValue, aSize);
     }
@@ -337,6 +353,10 @@ public:
     {
         bind(aName.c_str(), apValue, aSize);
     }
+    void bind(const std::string& aName, const void*           apValue, const size_t aSize)
+    {
+        bind(aName.c_str(), apValue, aSize);
+    }
     /**
      * @brief Bind a string value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      *
@@ -365,6 +385,10 @@ public:
      * @warning Uses the SQLITE_STATIC flag, avoiding a copy of the data. The string must remains unchanged while executing the statement.
      */
     void bindNoCopy(const std::string& aName, const void*        apValue, const int aSize)
+    {
+        bindNoCopy(aName.c_str(), apValue, aSize);
+    }
+    void bindNoCopy(const std::string& aName, const void*        apValue, const size_t aSize)
     {
         bindNoCopy(aName.c_str(), apValue, aSize);
     }

--- a/tests/Statement_test.cpp
+++ b/tests/Statement_test.cpp
@@ -407,6 +407,24 @@ TEST(Statement, bindings)
         EXPECT_EQ(7, query.getColumn(0).getInt64());
         EXPECT_EQ(12345678900000LL, query.getColumn(2).getInt64());
     }
+
+    // reset() with clearbindings() and new bindings
+    insert.reset();
+    insert.clearBindings();
+
+    // Height row with a vector of unsigned char as blob
+    {
+        const std::vector<char> blob = { 'b','l','\0','b' };
+        insert.bind(3, blob.data(), blob.size());
+        EXPECT_EQ(1, insert.exec());
+        EXPECT_EQ(SQLITE_DONE, db.getErrorCode());
+
+        // Check the result
+        query.executeStep();
+        EXPECT_TRUE(query.hasRow());
+        EXPECT_FALSE(query.isDone());
+        EXPECT_EQ(0, memcmp(blob.data(), &query.getColumn(3).getString()[0], blob.size()));
+    }
 }
 
 TEST(Statement, bindNoCopy)
@@ -446,6 +464,24 @@ TEST(Statement, bindNoCopy)
         EXPECT_STREQ(txt1, query.getColumn(1).getText());
         EXPECT_EQ(0, memcmp(&txt2[0], &query.getColumn(2).getString()[0], txt2.size()));
         EXPECT_EQ(0, memcmp(blob, &query.getColumn(3).getString()[0], sizeof(blob)));
+    }
+
+    // reset() with clearbindings() and new bindings
+    insert.reset();
+    insert.clearBindings();
+
+    // Insert a second row with a vector of unsigned char as blob
+    {
+        const std::vector<char> blob = { 'b','l','\0','b' };
+        insert.bindNoCopy(3, blob.data(), blob.size());
+        EXPECT_EQ(1, insert.exec());
+        EXPECT_EQ(SQLITE_DONE, db.getErrorCode());
+
+        // Check the result
+        query.executeStep();
+        EXPECT_TRUE(query.hasRow());
+        EXPECT_FALSE(query.isDone());
+        EXPECT_EQ(0, memcmp(blob.data(), &query.getColumn(3).getString()[0], blob.size()));
     }
 }
 


### PR DESCRIPTION
Fix #430 for a better support of standard containers

Also add a couple of tests (not covering all variants)