### PR TITLE
Fix crash on Windows due to forward declarations

### DIFF
--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -261,7 +261,7 @@ public:
      *
      * @warning assert in case of error
      */
-    ~Database() = default;
+    ~Database();
 
     // Deleter functor to use with smart pointers to close the SQLite database connection in an RAII fashion.
     struct Deleter

--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -83,7 +83,7 @@ public:
 
     /// Finalize and unregister the SQL query from the SQLite Database Connection.
     /// The finalization will be done by the destructor of the last shared pointer
-    ~Statement() = default;
+    ~Statement();
 
     /// Reset the statement to make it ready for a new execution by calling sqlite3_reset.
     /// Throws an exception on error.

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -79,6 +79,8 @@ Database::Database(const char* apFilename,
     }
 }
 
+Database::~Database() = default;
+
 // Deleter functor to use with smart pointers to close the SQLite database connection in an RAII fashion.
 void Database::Deleter::operator()(sqlite3* apSQLite)
 {

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -54,6 +54,8 @@ Statement::Statement(Statement&& aStatement) noexcept :
     aStatement.mbDone = false;
 }
 
+Statement::~Statement() = default;
+
 // Reset the statement to make it ready for a new execution (see also #clearBindings() below)
 void Statement::reset()
 {


### PR DESCRIPTION
In this commit, we address a bug that was causing a crash on Windows. The issue was due to the forward declaration of sqlite3 objects in the header files, which led to problems during destruction because the complete type information was unavailable at that point. To resolve this, we moved the default destructors for the Database and Statement classes from their respective headers to the implementation (.cpp) files. This ensures that the destructors have the full type information necessary for proper destruction, preventing the crash.