### PR TITLE
[Meson] update meson dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,8 @@
 project(
     'SQLiteCpp', 'cpp',
-    # SQLiteCpp requires C++11 support
-    default_options: ['cpp_std=c++11', 'warning_level=3'],
+    # SQLiteCpp supports C++11
+    # however newer versions of gtest requires C++14
+    default_options: ['cpp_std=c++14', 'warning_level=3'],
     license: 'MIT',
     version: '3.3.1',
 )
@@ -97,10 +98,14 @@ sqlitecpp_sample2_srcs = files(
 ## using MSVC headers requires c++14, if not will show an error on xstddef as: 
 ## 'auto' return without trailing return type; deduced return types are a C++14 extension
 if host_machine.system() == 'windows'
-    message('[WINDOWS] using c++14 standard')
-    sqlitecpp_opts += [
-        'cpp_std=c++14',
-    ]
+    ## check if the std version is less than c++14
+    if get_option('cpp_std').endswith('11')
+        message('[WINDOWS] using c++14 standard')
+        message('[WINDOWS] you can disable this warning by setting cpp_std to c++14 or newer')
+        sqlitecpp_opts += [
+            'cpp_std=c++14',
+        ]
+    endif
 endif
 # Options relative to SQLite and SQLiteC++ functions
 
@@ -280,6 +285,21 @@ if get_option('SQLITECPP_BUILD_TESTS')
                 'gtest',
                 main : true,
                 fallback: ['gtest', 'gtest_main_dep'])
+    # check if Gtest is newer than 1.14.0
+    # if so set the minimum standard to c++14
+    if gtest_dep.found() and gtest_dep.version().version_compare('>=1.14.0')
+        ## check if the std version is less than c++14
+        if get_option('cpp_std').version_compare('<c++14')
+            message('warning: current Gtest version requires c++14, setting the minimum standard to c++14')
+            message('warning: you can disable this warning by setting cpp_std to c++14 or newer')
+
+            sqlitecpp_test_args += [
+                'cpp_std=c++14',
+            ]
+        endif
+    endif
+
+
     sqlitecpp_test_dependencies = [
         gtest_dep,
         sqlitecpp_dep,

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,12 +1,13 @@
 [wrap-file]
-directory = googletest-release-1.12.1
-source_url = https://github.com/google/googletest/archive/release-1.12.1.tar.gz
-source_filename = gtest-1.12.1.tar.gz
-source_hash = 81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2
-patch_filename = gtest_1.12.1-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.12.1-1/get_patch
-patch_hash = 75143f11e174952bc768699fde3176511fe8e33b25dc6f6347d89e41648e99cf
-wrapdb_version = 1.12.1-1
+directory = googletest-1.14.0
+source_url = https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+source_filename = gtest-1.14.0.tar.gz
+source_hash = 8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7
+patch_filename = gtest_1.14.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.14.0-1/get_patch
+patch_hash = 2e693c7d3f9370a7aa6dac802bada0874d3198ad4cfdf75647b818f691182b50
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/gtest_1.14.0-1/gtest-1.14.0.tar.gz
+wrapdb_version = 1.14.0-1
 
 [provide]
 gtest = gtest_dep

--- a/subprojects/sqlite3.wrap
+++ b/subprojects/sqlite3.wrap
@@ -1,12 +1,13 @@
 [wrap-file]
-directory = sqlite-amalgamation-3400000
-source_url = https://sqlite.org/2022/sqlite-amalgamation-3400000.zip
-source_filename = sqlite-amalgamation-3400000.zip
-source_hash = 7c23eb51409315738c930a222cf7cd41518ae5823c41e60a81b93a07070ef22a
-patch_filename = sqlite3_3.40.0-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/sqlite3_3.40.0-1/get_patch
-patch_hash = 7780fd0908a57ffbf718d88b5930c7b551993352a9156d5a33573f6ea01768c2
-wrapdb_version = 3.40.0-1
+directory = sqlite-amalgamation-3420000
+source_url = https://www.sqlite.org/2023/sqlite-amalgamation-3420000.zip
+source_filename = sqlite-amalgamation-3420000.zip
+source_hash = 1cc824d0f5e675829fa37018318fda833ea56f7e9de2b41eddd9f7643b5ec29e
+patch_filename = sqlite3_3.42.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sqlite3_3.42.0-1/get_patch
+patch_hash = 821b2e49a9d3daea7415716c6958697de601bb66f66a5a176b18c1c86c48c9b8
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sqlite3_3.42.0-1/sqlite-amalgamation-3420000.zip
+wrapdb_version = 3.42.0-1
 
 [provide]
 sqlite3 = sqlite3_dep

--- a/subprojects/sqlitecpp.wrap
+++ b/subprojects/sqlitecpp.wrap
@@ -1,8 +1,0 @@
-[wrap-file]
-directory = SQLiteCpp-3.3.1
-source_url = https://github.com/SRombauts/SQLiteCpp/archive/refs/tags/3.3.1.zip
-source_filename = sqlitecpp-3.3.1.zip
-source_hash = e1bdc1ff47f201bc2b77703de1001ea5e525151fa57c22ed43f06335b4784603
-
-[provide]
-sqlitecpp = sqlitecpp_dep


### PR DESCRIPTION
this PR only affects meson, however a later change could be made for CMake
updates the following depenencies:
 - GTests to 1.14.0
 - sqlite to 3.42.0
makes 
sets the recommended version to C++14 as Gtest now requires C++14, additionally shows a warning and sets it to c++14 if
- C++11 is set and is on windows (this was #354 but now checks if is C++11 and shows a warning instead of setting it to C++14 so it does not revert when using a newer version)
- C++11 is set and uses [GTest 1.14.0](https://github.com/google/googletest/releases/tag/v1.14.0) or greater,  for more information check [Google's Foundational C++ Support Policy](https://opensource.google/documentation/policies/cplusplus-support)