### PR TITLE
Update meson dependencies [Meson only]

### DIFF
--- a/examples/example1/meson.build
+++ b/examples/example1/meson.build
@@ -1,8 +1,5 @@
 
-
-example1_sources = files(
-    'main.cpp'
-)
+example1_sources = files('main.cpp')
 
 example1_args = []
 
@@ -11,10 +8,11 @@ if host_machine.system() == 'windows'
     example1_args += ['-D_CRT_SECURE_NO_WARNINGS']
 endif
 
-
-sqlitecpp_demo1_exe = executable('SQLITECPP_sample_demo1',
-                            sqlitecpp_sample1_srcs,
-                            dependencies: sqlitecpp_dep,
-                            # inherit the default options from sqlitecpp
-                            override_options: sqlitecpp_opts,
-                            cpp_args: example1_args,)
+executable(
+    'SQLITECPP_sample_demo1',
+    sources: example1_sources,
+    dependencies: sqlitecpp_dep,
+    # inherit the default options from sqlitecpp
+    override_options: sqlitecpp_opts,
+    cpp_args: example1_args,
+)

--- a/examples/example2/meson.build
+++ b/examples/example2/meson.build
@@ -1,14 +1,13 @@
-example2_srcs = files(
-    'src/main.cpp'
-)
+example2_srcs = files('src/main.cpp')
 
 # if running on windows define _CRT_SECURE_NO_WARNINGS
 example2_args = []
 
-
-sqlitecpp_demo2_exe = executable('SQLITECPP_sample_demo2',
-                            sqlitecpp_sample2_srcs,
-                            dependencies: sqlitecpp_dep,
-                            # inherit the default options from sqlitecpp
-                            override_options: sqlitecpp_opts,
-                            cpp_args: example2_args)
+executable(
+    'SQLITECPP_sample_demo2',
+    example2_srcs,
+    dependencies: sqlitecpp_dep,
+    # inherit the default options from sqlitecpp
+    override_options: sqlitecpp_opts,
+    cpp_args: example2_args,
+)

--- a/meson.build
+++ b/meson.build
@@ -86,14 +86,6 @@ sqlitecpp_test_srcs = files(
 )
 sqlitecpp_test_args = []
 
-## samples
-
-sqlitecpp_sample1_srcs = files(
-    'examples/example1/main.cpp',
-)
-sqlitecpp_sample2_srcs = files(
-    'examples/example2/src/main.cpp',
-)
 
 ## using MSVC headers requires c++14, if not will show an error on xstddef as: 
 ## 'auto' return without trailing return type; deduced return types are a C++14 extension

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = googletest-1.14.0
-source_url = https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
-source_filename = gtest-1.14.0.tar.gz
-source_hash = 8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7
-patch_filename = gtest_1.14.0-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.14.0-1/get_patch
-patch_hash = 2e693c7d3f9370a7aa6dac802bada0874d3198ad4cfdf75647b818f691182b50
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/gtest_1.14.0-1/gtest-1.14.0.tar.gz
-wrapdb_version = 1.14.0-1
+directory = googletest-1.15.0
+source_url = https://github.com/google/googletest/archive/refs/tags/v1.15.0.tar.gz
+source_filename = gtest-1.15.0.tar.gz
+source_hash = 7315acb6bf10e99f332c8a43f00d5fbb1ee6ca48c52f6b936991b216c586aaad
+patch_filename = gtest_1.15.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.15.0-1/get_patch
+patch_hash = 5f8e484c48fdc1029c7fd08807bd2615f8c9d16f90df6d81984f4f292752c925
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/gtest_1.15.0-1/gtest-1.15.0.tar.gz
+wrapdb_version = 1.15.0-1
 
 [provide]
 gtest = gtest_dep

--- a/subprojects/sqlite3.wrap
+++ b/subprojects/sqlite3.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = sqlite-amalgamation-3420000
-source_url = https://www.sqlite.org/2023/sqlite-amalgamation-3420000.zip
-source_filename = sqlite-amalgamation-3420000.zip
-source_hash = 1cc824d0f5e675829fa37018318fda833ea56f7e9de2b41eddd9f7643b5ec29e
-patch_filename = sqlite3_3.42.0-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/sqlite3_3.42.0-1/get_patch
-patch_hash = 821b2e49a9d3daea7415716c6958697de601bb66f66a5a176b18c1c86c48c9b8
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sqlite3_3.42.0-1/sqlite-amalgamation-3420000.zip
-wrapdb_version = 3.42.0-1
+directory = sqlite-amalgamation-3460100
+source_url = https://www.sqlite.org/2024/sqlite-amalgamation-3460100.zip
+source_filename = sqlite-amalgamation-3460100.zip
+source_hash = 77823cb110929c2bcb0f5d48e4833b5c59a8a6e40cdea3936b99e199dbbe5784
+patch_filename = sqlite3_3.46.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sqlite3_3.46.1-1/get_patch
+patch_hash = 1358b931e30a454e55dbedbc28d5844946a17c68b45a5333093152d7af75982b
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sqlite3_3.46.1-1/sqlite-amalgamation-3460100.zip
+wrapdb_version = 3.46.1-1
 
 [provide]
 sqlite3 = sqlite3_dep


### PR DESCRIPTION
makes the following changes
- update meson wrap dependencies
  - update gtest 1.14.0 -> 1.15.0
  - update sqlite 3.42.0 -> 3.46.1
- removed redundant variables that pointed to the same sources in example executables