### PR TITLE
Macos ci fix

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -59,8 +59,8 @@ jobs:
       run: echo "${{matrix.config.extra_path}}" >> $GITHUB_PATH
     - name: install prerequisites
       run: |
-        # asuming that python and pip are already installed
-        pip3 install meson ninja
+        # asuming that python and pipx are already installed
+        pipx install meson ninja
     - name: setup meson project
       env: # set proper compilers and linkers for meson
         CC: ${{matrix.config.cc}}


### PR DESCRIPTION
fixes a CI issue in OSX due to [PEP-668](https://peps.python.org/pep-0668/)
pip3 was used to install meson and ninja build, pipx is a drop in replacement for this use case.