### PR TITLE
tests/Database_test.cpp: fix a warning around `#endif`

### DIFF
--- a/tests/Database_test.cpp
+++ b/tests/Database_test.cpp
@@ -563,7 +563,7 @@ TEST(Database, getHeaderInfo)
 // NOTE on macOS FindSQLite3 find an unrelated sqlite3.h from Mono.framework that doesn't match the actual package version!
 #if defined(SQLITECPP_INTERNAL_SQLITE) || !defined(__APPLE__)
         EXPECT_EQ(h.sqliteVersion, SQLITE_VERSION_NUMBER);
-#endif  && !defined(__APPLE__)
+#endif
     }
     remove("test.db3");
 }


### PR DESCRIPTION
Without the change `gcc` detects unexpected tokens as:

    /build/source/tests/Database_test.cpp:566:9: warning: extra tokens at end of #endif directive [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wendif-labels-Wendif-labels8;;]
      566 | #endif  && !defined(__APPLE__)
          |         ^~