### PR TITLE
Release 3.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,3 +274,18 @@ Version 3.3.2 - 2024 Aug 16
 - Update SQLite from 3.43.0 to 3.46.1 (2024-08-13) (#461) and (#477)
 - Explicitly =delete; Statement::bindNoCopy(..., std::string&&) (#469)
 
+Version 3.3.3 - 2025 May 20
+
+- Update SQLite from 3.46.1 to 3.49.2 (2025-05-07) (#505)
+- SQLiteCpp/Statement.h: add missing `<cstdint>` include (#488)
+- sqlite3: set SQLITE_OMIT_LOAD_EXTENSION (#496)
+- tests/Database_test.cpp: fix a warning around `#endif` (#489)
+- Add a Github Dependabot config file (#480)
+- Bump actions/checkout from 3 to 4 in (#482)
+- Replace all double-quoted string literals in unit test (#483)
+- Use explicit versions of Ubuntu images instead of latest (#484)
+- Test linking with builtin libsqlite3-dev package on Ubuntu (#485)
+- Add logic to use different FindPackage for python if cmake is above 3.12 (#454)
+- Update googletest to v1.16.0 (#506)
+- update meson dependencies (#508)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # or copy at http://opensource.org/licenses/MIT)
 cmake_minimum_required(VERSION 3.5)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake") # custom CMake modules like FindSQLiteCpp
-project(SQLiteCpp VERSION 3.3.2)
+project(SQLiteCpp VERSION 3.3.3)
 
 # SQLiteC++ 3.x requires C++11 features
 if (NOT CMAKE_CXX_STANDARD)

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = SQLiteC++
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.3.2
+PROJECT_NUMBER         = 3.3.3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/SQLiteCpp/SQLiteCpp.h
+++ b/include/SQLiteCpp/SQLiteCpp.h
@@ -41,6 +41,6 @@
  *
  * WARNING: shall always be updated in sync with PROJECT_VERSION in CMakeLists.txt
  */
-#define SQLITECPP_VERSION           "3.03.02"   // 3.3.2
-#define SQLITECPP_VERSION_NUMBER     3003002    // 3.3.2
+#define SQLITECPP_VERSION           "3.03.03"   // 3.3.3
+#define SQLITECPP_VERSION_NUMBER     3003003    // 3.3.3
 

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>SQLiteCpp</name>
-  <version>3.3.2</version>
+  <version>3.3.3</version>
   <description>A smart and easy to use C++ SQLite3 wrapper.</description>
 
   <maintainer email="sebastien.rombauts@gmail.com">Sébastien Rombauts</maintainer>


### PR DESCRIPTION
## What's Changed
* Update SQLite from 3.46.1 to 3.49.2 (2025-05-07) by @SRombauts in https://github.com/SRombauts/SQLiteCpp/pull/505
* Add a Github Dependabot config file by @SRombauts in https://github.com/SRombauts/SQLiteCpp/pull/480
* Bump actions/checkout from 3 to 4 by @dependabot in https://github.com/SRombauts/SQLiteCpp/pull/482
* Replace all double-quoted string literals by single quotes in unit test by @SRombauts in https://github.com/SRombauts/SQLiteCpp/pull/483
* Use explicit versions of Ubuntu images instead of latest by @SRombauts in https://github.com/SRombauts/SQLiteCpp/pull/484
* Test linking with builtin libsqlite3-dev package on Ubuntu by @SRombauts in https://github.com/SRombauts/SQLiteCpp/pull/485
* Add logic to use different FindPackage for python if cmake is above 3.12 by @syntheticgio in https://github.com/SRombauts/SQLiteCpp/pull/454
* tests/Database_test.cpp: fix a warning around `#endif` by @trofi in https://github.com/SRombauts/SQLiteCpp/pull/489
* SQLiteCpp/Statement.h: add missing `<cstdint>` include by @trofi in https://github.com/SRombauts/SQLiteCpp/pull/488
* sqlite3: set SQLITE_OMIT_LOAD_EXTENSION by @brt-v in https://github.com/SRombauts/SQLiteCpp/pull/496
* Update googletest to v1.16.0 by @SRombauts in https://github.com/SRombauts/SQLiteCpp/pull/506
* update meson dependencies by @UnixY2K in https://github.com/SRombauts/SQLiteCpp/pull/508

## New Contributors
* @syntheticgio made their first contribution in https://github.com/SRombauts/SQLiteCpp/pull/454
* @trofi made their first contribution in https://github.com/SRombauts/SQLiteCpp/pull/489
* @brt-v made their first contribution in https://github.com/SRombauts/SQLiteCpp/pull/496

**Full Changelog**: https://github.com/SRombauts/SQLiteCpp/compare/3.3.2...3.3.3