### PR TITLE
update meson dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,10 +4,11 @@ project(
     # however newer versions of gtest requires C++14
     default_options: ['cpp_std=c++14', 'warning_level=3'],
     license: 'MIT',
-    version: '3.3.2',
+    version: '3.3.3',
 )
 
 cxx = meson.get_compiler('cpp')
+cpp_std = get_option('cpp_std')
 
 ## at best we might try to test if this code compiles
 ## testing for compilers or platforms is not reliable enough
@@ -91,11 +92,12 @@ sqlitecpp_test_args = []
 ## 'auto' return without trailing return type; deduced return types are a C++14 extension
 if host_machine.system() == 'windows'
     ## check if the std version is less than c++14
-    if get_option('cpp_std').endswith('11')
-        message('[WINDOWS] using c++14 standard')
-        message('[WINDOWS] you can disable this warning by setting cpp_std to c++14 or newer')
+    if cpp_std.version_compare('<c++14')
+        message('[WINDOWS] setting minimal version to c++14')
+        message('[WINDOWS] you can disable this warning by setting cpp_std to c++14 or newer.')
+        cpp_std = 'c++14'
         sqlitecpp_opts += [
-            'cpp_std=c++14',
+            'cpp_std=' + cpp_std,
         ]
     endif
 endif
@@ -277,16 +279,22 @@ if get_option('SQLITECPP_BUILD_TESTS')
                 'gtest',
                 main : true,
                 fallback: ['gtest', 'gtest_main_dep'])
-    # check if Gtest is newer than 1.14.0
-    # if so set the minimum standard to c++14
-    if gtest_dep.found() and gtest_dep.version().version_compare('>=1.14.0')
-        ## check if the std version is less than c++14
-        if get_option('cpp_std').version_compare('<c++14')
-            message('warning: current Gtest version requires c++14, setting the minimum standard to c++14')
-            message('warning: you can disable this warning by setting cpp_std to c++14 or newer')
-
-            sqlitecpp_test_args += [
-                'cpp_std=c++14',
+    # check for the current version of gtest as newer versions require newer C++ standards
+    if gtest_dep.found()
+        gtest_version = gtest_dep.version()
+        minimum_standard = 'none'
+        required_std_format = 'current Gtest version requires at least @0@, setting the minimum standard to @0@. You can disable this warning by setting cpp_std to @0@ or newer.'
+        ## gtest 1.17.0 requires c++17 while gtest 1.14.0 requires c++14
+        if gtest_version.version_compare('>=1.17.0') and cpp_std.version_compare('<c++17')
+            minimum_standard = 'c++17'
+        elif gtest_version.version_compare('>=1.14.0') and cpp_std.version_compare('<c++14')
+            minimum_standard = 'c++14'
+        endif
+        if minimum_standard != 'none'
+            warning(required_std_format.format(minimum_standard))
+            cpp_std = minimum_standard
+            sqlitecpp_opts += [
+                'cpp_std=' + cpp_std,
             ]
         endif
     endif

--- a/subprojects/sqlite3.wrap
+++ b/subprojects/sqlite3.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = sqlite-amalgamation-3460100
-source_url = https://www.sqlite.org/2024/sqlite-amalgamation-3460100.zip
-source_filename = sqlite-amalgamation-3460100.zip
-source_hash = 77823cb110929c2bcb0f5d48e4833b5c59a8a6e40cdea3936b99e199dbbe5784
-patch_filename = sqlite3_3.46.1-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/sqlite3_3.46.1-1/get_patch
-patch_hash = 1358b931e30a454e55dbedbc28d5844946a17c68b45a5333093152d7af75982b
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sqlite3_3.46.1-1/sqlite-amalgamation-3460100.zip
-wrapdb_version = 3.46.1-1
+directory = sqlite-amalgamation-3490200
+source_url = https://www.sqlite.org/2025/sqlite-amalgamation-3490200.zip
+source_filename = sqlite-amalgamation-3490200.zip
+source_hash = 921fc725517a694df7df38a2a3dfede6684024b5788d9de464187c612afb5918
+patch_filename = sqlite3_3.49.2-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sqlite3_3.49.2-1/get_patch
+patch_hash = e3eef046409329c5c1ca8308255caa2266710fc1b9d8695fdedd04cebe42a690
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sqlite3_3.49.2-1/sqlite-amalgamation-3490200.zip
+wrapdb_version = 3.49.2-1
 
 [provide]
 sqlite3 = sqlite3_dep


### PR DESCRIPTION
- updates fallback gtest to 1.15.2
- updates fallback sqlite3 to 3.49.2
- adds additional checks of the default c++ standard version if GTest is >= 1.17.0
- bumps the version to 3.3.3