### PR TITLE
fix: update the c++ version selection process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 # Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
 # or copy at http://opensource.org/licenses/MIT)
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.8)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake") # custom CMake modules like FindSQLiteCpp
 project(SQLiteCpp VERSION 3.3.3)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,15 +8,6 @@ cmake_minimum_required(VERSION 3.5)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake") # custom CMake modules like FindSQLiteCpp
 project(SQLiteCpp VERSION 3.3.3)
 
-# SQLiteC++ 3.x requires C++11 features
-if (NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 11)
-elseif (CMAKE_CXX_STANDARD LESS 11)
-    message(WARNING "CMAKE_CXX_STANDARD has been set to '${CMAKE_CXX_STANDARD}' which is lower than the minimum required standard (c++11).")
-endif ()
-message(STATUS "Using c++ standard c++${CMAKE_CXX_STANDARD}")
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 message (STATUS "CMake version: ${CMAKE_VERSION}")
 message (STATUS "Project version: ${PROJECT_VERSION}")
 
@@ -212,6 +203,9 @@ endif()
 
 # add sources of the wrapper as a "SQLiteCpp" static library
 add_library(SQLiteCpp ${SQLITECPP_SRC} ${SQLITECPP_INC} ${SQLITECPP_DOC} ${SQLITECPP_SCRIPT})
+
+# set minimum version to c++11
+target_compile_features(SQLiteCpp PUBLIC cxx_std_11)
 
 # Options relative to SQLite and SQLiteC++ functions
 

--- a/examples/example2/CMakeLists.txt
+++ b/examples/example2/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 # Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
 # or copy at http://opensource.org/licenses/MIT) 
-cmake_minimum_required(VERSION 3.1) # for "CMAKE_CXX_STANDARD" version
+cmake_minimum_required(VERSION 3.8) # for "CMAKE_CXX_STANDARD" version
 project(SQLiteCpp_Example VERSION 2.0)
 
 # SQLiteC++ 3.x now requires C++11 compiler


### PR DESCRIPTION
The c++ version should be set via `target_compile_features(SQLiteCpp PUBLIC cxx_std_11)`
This only sets this as a minimum version for this target, and not all targets.