### PR TITLE
std::string_view support

### DIFF
--- a/include/SQLiteCpp/Column.h
+++ b/include/SQLiteCpp/Column.h
@@ -16,6 +16,9 @@
 
 #include <string>
 #include <memory>
+#if __cplusplus >= 201703L // C++17
+#include <string_view>
+#endif
 
 // Forward declarations to avoid inclusion of <sqlite3.h> in a header
 struct sqlite3_stmt;
@@ -102,6 +105,18 @@ public:
      * Note this correctly handles strings that contain null bytes.
      */
     std::string getString() const;
+
+#if __cplusplus >= 201703L // C++17
+    /**
+     * @brief Return a std::string_view for a TEXT or BLOB column.
+     *
+     * Note this correctly handles strings that contain null bytes.
+     *
+     * @warning returned string_view is only valid until there is a type
+     *          conversion or the statement is stepped or reset.
+     */
+    std::string_view getStringView() const;
+#endif
 
     /**
      * @brief Return the type of the value of the column using sqlite3_column_type()

--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -18,7 +18,6 @@
 // c++17: macOS unless targetting compatibility with macOS < 10.15
 #ifndef SQLITECPP_HAVE_STD_EXPERIMENTAL_FILESYSTEM
 #if __cplusplus >= 201703L
-    #include <string_view>
     #if defined(__MINGW32__) || defined(__MINGW64__)
         #if __GNUC__ > 8 // MinGW requires GCC version > 8 for std::filesystem
             #define SQLITECPP_HAVE_STD_FILESYSTEM
@@ -524,71 +523,99 @@ public:
     void loadExtension(const char* apExtensionName, const char* apEntryPointName);
 
     /**
-    * @brief Set the key for the current sqlite database instance.
-    *
-    *  This is the equivalent of the sqlite3_key call and should thus be called
-    *  directly after opening the database.
-    *  Open encrypted database -> call db.key("secret") -> database ready
-    *
-    * @param[in] aKey   Key to decode/encode the database
-    *
-    * @throw SQLite::Exception in case of error
-    */
-#if __cplusplus >= 201703L // C++17
-    void key(const std::string_view aKey) const;
-#else
-    void key(const std::string& aKey) const;
-#endif
+     * @brief Set the key for the current sqlite database instance.
+     *
+     *  This is the equivalent of the sqlite3_key call and should thus be called
+     *  directly after opening the database.
+     *  Open encrypted database -> call db.key("secret") -> database ready
+     *
+     * @param[in] aKey   Key to decode/encode the database
+     *
+     * @throw SQLite::Exception in case of error
+     */
+    void key(const char* apKey, const int aSize ) const;
 
     /**
-    * @brief Reset the key for the current sqlite database instance.
-    *
-    *  This is the equivalent of the sqlite3_rekey call and should thus be called
-    *  after the database has been opened with a valid key. To decrypt a
-    *  database, call this method with an empty string.
-    *  Open normal database -> call db.rekey("secret") -> encrypted database, database ready
-    *  Open encrypted database -> call db.key("secret") -> call db.rekey("newsecret") -> change key, database ready
-    *  Open encrypted database -> call db.key("secret") -> call db.rekey("") -> decrypted database, database ready
-    *
-    * @param[in] aNewKey   New key to encode the database
-    *
-    * @throw SQLite::Exception in case of error
-    */
-#if __cplusplus >= 201703L // C++17
-    void rekey(const std::string_view aNewKey) const;
-#else
-    void rekey(const std::string& aNewKey) const;
-#endif
+     * @brief Set the key for the current sqlite database instance.
+     *
+     *  This is the equivalent of the sqlite3_key call and should thus be called
+     *  directly after opening the database.
+     *  Open encrypted database -> call db.key("secret") -> database ready
+     *
+     * @param[in] aKey   Key to decode/encode the database
+     *
+     * @throw SQLite::Exception in case of error
+     */
+    void key(const std::string& aKey) const
+    {
+        key(aKey.data(), aKey.size());
+    }
 
     /**
-    * @brief Test if a file contains an unencrypted database.
-    *
-    *  This is a simple test that reads the first bytes of a database file and
-    *  compares them to the standard header for unencrypted databases. If the
-    *  header does not match the standard string, we assume that we have an
-    *  encrypted file.
-    *
-    * @param[in] aFilename path/uri to a file
-    *
-    * @return true if the database has the standard header.
-    *
-    * @throw SQLite::Exception in case of error
-    */
+     * @brief Reset the key for the current sqlite database instance.
+     *
+     *  This is the equivalent of the sqlite3_rekey call and should thus be called
+     *  after the database has been opened with a valid key. To decrypt a
+     *  database, call this method with an empty string.
+     *  Open normal database -> call db.rekey("secret") -> encrypted database, database ready
+     *  Open encrypted database -> call db.key("secret") -> call db.rekey("newsecret") -> change key, database ready
+     *  Open encrypted database -> call db.key("secret") -> call db.rekey("") -> decrypted database, database ready
+     *
+     * @param[in] apNewKey   New key to encode the database
+     * @param[in] aSize      Length of apNewKey
+     *
+     * @throw SQLite::Exception in case of error
+     */
+    void rekey(const char* apNewKey, const int aSize ) const;
+
+    /**
+     * @brief Reset the key for the current sqlite database instance.
+     *
+     *  This is the equivalent of the sqlite3_rekey call and should thus be called
+     *  after the database has been opened with a valid key. To decrypt a
+     *  database, call this method with an empty string.
+     *  Open normal database -> call db.rekey("secret") -> encrypted database, database ready
+     *  Open encrypted database -> call db.key("secret") -> call db.rekey("newsecret") -> change key, database ready
+     *  Open encrypted database -> call db.key("secret") -> call db.rekey("") -> decrypted database, database ready
+     *
+     * @param[in] aNewKey   New key to encode the database
+     *
+     * @throw SQLite::Exception in case of error
+     */
+    void rekey(const std::string& aNewKey) const
+    {
+        rekey(aNewKey.data(), aNewKey.size());
+    }
+
+    /**
+     * @brief Test if a file contains an unencrypted database.
+     *
+     *  This is a simple test that reads the first bytes of a database file and
+     *  compares them to the standard header for unencrypted databases. If the
+     *  header does not match the standard string, we assume that we have an
+     *  encrypted file.
+     *
+     * @param[in] aFilename path/uri to a file
+     *
+     * @return true if the database has the standard header.
+     *
+     * @throw SQLite::Exception in case of error
+     */
     static bool isUnencrypted(const std::string& aFilename);
 
     /**
-    * @brief Parse SQLite header data from a database file.
-    *
-    *  This function reads the first 100 bytes of a SQLite database file
-    *  and reconstructs groups of individual bytes into the associated fields
-    *  in a Header object.
-    *
-    * @param[in] aFilename path/uri to a file
-    *
-    * @return Header object containing file data
-    *
-    * @throw SQLite::Exception in case of error
-    */
+     * @brief Parse SQLite header data from a database file.
+     *
+     *  This function reads the first 100 bytes of a SQLite database file
+     *  and reconstructs groups of individual bytes into the associated fields
+     *  in a Header object.
+     *
+     * @param[in] aFilename path/uri to a file
+     *
+     * @return Header object containing file data
+     *
+     * @throw SQLite::Exception in case of error
+     */
     static Header getHeaderInfo(const std::string& aFilename);
 
     // Parse SQLite header data from a database file.

--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -18,6 +18,7 @@
 // c++17: macOS unless targetting compatibility with macOS < 10.15
 #ifndef SQLITECPP_HAVE_STD_EXPERIMENTAL_FILESYSTEM
 #if __cplusplus >= 201703L
+    #include <string_view>
     #if defined(__MINGW32__) || defined(__MINGW64__)
         #if __GNUC__ > 8 // MinGW requires GCC version > 8 for std::filesystem
             #define SQLITECPP_HAVE_STD_FILESYSTEM
@@ -533,7 +534,11 @@ public:
     *
     * @throw SQLite::Exception in case of error
     */
+#if __cplusplus >= 201703L // C++17
+    void key(const std::string_view aKey) const;
+#else
     void key(const std::string& aKey) const;
+#endif
 
     /**
     * @brief Reset the key for the current sqlite database instance.
@@ -549,7 +554,11 @@ public:
     *
     * @throw SQLite::Exception in case of error
     */
+#if __cplusplus >= 201703L // C++17
+    void rekey(const std::string_view aNewKey) const;
+#else
     void rekey(const std::string& aNewKey) const;
+#endif
 
     /**
     * @brief Test if a file contains an unencrypted database.

--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -149,7 +149,7 @@ public:
      *
      * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
      */
-    void bind(const int aIndex, const std::string_view&  aValue);
+    void bind(const int aIndex, const std::string_view  aValue);
 #endif
 
     /**
@@ -178,7 +178,7 @@ public:
      *
      * @warning Uses the SQLITE_STATIC flag, avoiding a copy of the data. The string must remains unchanged while executing the statement.
      */
-    void bindNoCopy(const int aIndex, const std::string_view&    aValue);
+    void bindNoCopy(const int aIndex, const std::string_view    aValue);
 #endif
     /**
      * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1).
@@ -242,6 +242,17 @@ public:
     {
         bind(getIndex(apName), aValue);
     }
+#if __cplusplus >= 201703L // C++17
+    /**
+     * @brief Bind a string value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
+     *
+     * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
+     */
+    void bind(const char* apName, const std::string_view    aValue)
+    {
+        bind(getIndex(apName), aValue);
+    }
+#endif
     /**
      * @brief Bind a string value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      *
@@ -269,6 +280,19 @@ public:
     {
         bind(getIndex(apName), apValue, aSize);
     }
+#if __cplusplus >= 201703L // C++17
+    /**
+     * @brief Bind a string value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
+     *
+     * The string can contain null characters as it is binded using its size.
+     *
+     * @warning Uses the SQLITE_STATIC flag, avoiding a copy of the data. The string must remains unchanged while executing the statement.
+     */
+    void bindNoCopy(const char* apName, const std::string_view  aValue)
+    {
+        bindNoCopy(getIndex(apName), aValue);
+    }
+#endif
     /**
      * @brief Bind a string value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      *
@@ -343,6 +367,18 @@ public:
     {
         bind(aName.c_str(), aValue);
     }
+
+#if __cplusplus >= 201703L // C++17
+    /**
+     * @brief Bind a string value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
+     *
+     * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
+     */
+    void bind(const std::string& aName, const std::string_view    aValue)
+    {
+        bind(aName.c_str(), aValue);
+    }
+#endif
     /**
      * @brief Bind a string value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      *
@@ -370,6 +406,21 @@ public:
     {
         bind(aName.c_str(), apValue, aSize);
     }
+    
+#if __cplusplus >= 201703L // C++17
+    /**
+     * @brief Bind a string value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
+     *
+     * The string can contain null characters as it is binded using its size.
+     *
+     * @warning Uses the SQLITE_STATIC flag, avoiding a copy of the data. The string must remains unchanged while executing the statement.
+     */
+    void bindNoCopy(const std::string& aName, const std::string& aValue)
+    {
+        bindNoCopy(aName.c_str(), aValue);
+    }
+#endif
+
     /**
      * @brief Bind a string value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      *

--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -18,6 +18,9 @@
 #include <string>
 #include <map>
 #include <memory>
+#if __cplusplus >= 201703L // C++17
+#include <string_view>
+#endif
 
 // Forward declarations to avoid inclusion of <sqlite3.h> in a header
 struct sqlite3;
@@ -139,6 +142,16 @@ public:
      * @brief Bind a double (64bits float) value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
     void bind(const int aIndex, const double        aValue);
+
+#if __cplusplus >= 201703L // C++17
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
+     *
+     * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
+     */
+    void bind(const int aIndex, const std::string_view&  aValue);
+#endif
+
     /**
      * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      *
@@ -157,6 +170,16 @@ public:
      * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
      */
     void bind(const int aIndex, const void*         apValue, const int aSize);
+#if __cplusplus >= 201703L // C++17
+    /**
+     * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1).
+     *
+     * The string can contain null characters as it is binded using its size.
+     *
+     * @warning Uses the SQLITE_STATIC flag, avoiding a copy of the data. The string must remains unchanged while executing the statement.
+     */
+    void bindNoCopy(const int aIndex, const std::string_view&    aValue);
+#endif
     /**
      * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1).
      *

--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -415,7 +415,7 @@ public:
      *
      * @warning Uses the SQLITE_STATIC flag, avoiding a copy of the data. The string must remains unchanged while executing the statement.
      */
-    void bindNoCopy(const std::string& aName, const std::string& aValue)
+    void bindNoCopy(const std::string& aName, const std::string_view aValue)
     {
         bindNoCopy(aName.c_str(), aValue);
     }

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -224,13 +224,17 @@ void Database::loadExtension(const char* apExtensionName, const char *apEntryPoi
 }
 
 // Set the key for the current sqlite database instance.
+#if __cplusplus >= 201703L // C++17
+void Database::key(const std::string_view aKey) const
+#else
 void Database::key(const std::string& aKey) const
+#endif
 {
     int passLen = static_cast<int>(aKey.length());
 #ifdef SQLITE_HAS_CODEC
     if (passLen > 0)
     {
-        const int ret = sqlite3_key(getHandle(), aKey.c_str(), passLen);
+        const int ret = sqlite3_key(getHandle(), aKey.data(), passLen);
         check(ret);
     }
 #else // SQLITE_HAS_CODEC
@@ -242,13 +246,17 @@ void Database::key(const std::string& aKey) const
 }
 
 // Reset the key for the current sqlite database instance.
+#if __cplusplus >= 201703L // C++17
+void Database::rekey(const std::string_view aNewKey) const
+#else
 void Database::rekey(const std::string& aNewKey) const
+#endif
 {
 #ifdef SQLITE_HAS_CODEC
     int passLen = aNewKey.length();
     if (passLen > 0)
     {
-        const int ret = sqlite3_rekey(getHandle(), aNewKey.c_str(), passLen);
+        const int ret = sqlite3_rekey(getHandle(), aNewKey.data(), passLen);
         check(ret);
     }
     else

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -224,21 +224,18 @@ void Database::loadExtension(const char* apExtensionName, const char *apEntryPoi
 }
 
 // Set the key for the current sqlite database instance.
-#if __cplusplus >= 201703L // C++17
-void Database::key(const std::string_view aKey) const
-#else
-void Database::key(const std::string& aKey) const
-#endif
+void Database::key(const char* apKey, const int aSize) const
 {
-    int passLen = static_cast<int>(aKey.length());
 #ifdef SQLITE_HAS_CODEC
-    if (passLen > 0)
+    if (aSize > 0)
     {
-        const int ret = sqlite3_key(getHandle(), aKey.data(), passLen);
+        const int ret = sqlite3_key(getHandle(), apKey, aSize);
         check(ret);
     }
 #else // SQLITE_HAS_CODEC
-    if (passLen > 0)
+    // Silence unused parameter warning
+    static_cast<void>(apKey);
+    if (aSize > 0)
     {
         throw SQLite::Exception("No encryption support, recompile with SQLITE_HAS_CODEC to enable.");
     }
@@ -246,17 +243,12 @@ void Database::key(const std::string& aKey) const
 }
 
 // Reset the key for the current sqlite database instance.
-#if __cplusplus >= 201703L // C++17
-void Database::rekey(const std::string_view aNewKey) const
-#else
-void Database::rekey(const std::string& aNewKey) const
-#endif
+void Database::rekey(const char* apNewKey, const int aSize) const
 {
 #ifdef SQLITE_HAS_CODEC
-    int passLen = aNewKey.length();
-    if (passLen > 0)
+    if (aSize > 0)
     {
-        const int ret = sqlite3_rekey(getHandle(), aNewKey.data(), passLen);
+        const int ret = sqlite3_rekey(getHandle(), apNewKey, aSize);
         check(ret);
     }
     else
@@ -265,7 +257,10 @@ void Database::rekey(const std::string& aNewKey) const
         check(ret);
     }
 #else // SQLITE_HAS_CODEC
-    static_cast<void>(aNewKey); // silence unused parameter warning
+    // Silence unused parameter warnings
+    static_cast<void>(apNewKey);
+    static_cast<void>(aSize);
+
     throw SQLite::Exception("No encryption support, recompile with SQLITE_HAS_CODEC to enable.");
 #endif // SQLITE_HAS_CODEC
 }

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -108,6 +108,20 @@ void Statement::bind(const int aIndex, const double aValue)
     check(ret);
 }
 
+#if __cplusplus >= 201703L // c++17
+/**
+ * @brief Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
+ *
+ * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
+ */
+void Statement::bind(const int aIndex, const std::string_view&  aValue) {
+    const int ret = sqlite3_bind_text(getPreparedStatement(), aIndex, aValue.data(),
+                                      static_cast<int>(aValue.size()), SQLITE_TRANSIENT);
+    check(ret);
+}
+#endif
+
+
 // Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bind(const int aIndex, const std::string& aValue)
 {
@@ -129,6 +143,16 @@ void Statement::bind(const int aIndex, const void* apValue, const int aSize)
     const int ret = sqlite3_bind_blob(getPreparedStatement(), aIndex, apValue, aSize, SQLITE_TRANSIENT);
     check(ret);
 }
+
+#if __cplusplus >= 201703L // C++17
+// Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
+void Statement::bindNoCopy(const int aIndex, const std::string_view& aValue)
+{
+    const int ret = sqlite3_bind_text(getPreparedStatement(), aIndex, aValue.data(),
+                                      static_cast<int>(aValue.size()), SQLITE_STATIC);
+    check(ret);
+}
+#endif
 
 // Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bindNoCopy(const int aIndex, const std::string& aValue)

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -114,7 +114,7 @@ void Statement::bind(const int aIndex, const double aValue)
  *
  * @note Uses the SQLITE_TRANSIENT flag, making a copy of the data, for SQLite internal use
  */
-void Statement::bind(const int aIndex, const std::string_view&  aValue) {
+void Statement::bind(const int aIndex, const std::string_view  aValue) {
     const int ret = sqlite3_bind_text(getPreparedStatement(), aIndex, aValue.data(),
                                       static_cast<int>(aValue.size()), SQLITE_TRANSIENT);
     check(ret);
@@ -146,7 +146,7 @@ void Statement::bind(const int aIndex, const void* apValue, const int aSize)
 
 #if __cplusplus >= 201703L // C++17
 // Bind a string value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
-void Statement::bindNoCopy(const int aIndex, const std::string_view& aValue)
+void Statement::bindNoCopy(const int aIndex, const std::string_view aValue)
 {
     const int ret = sqlite3_bind_text(getPreparedStatement(), aIndex, aValue.data(),
                                       static_cast<int>(aValue.size()), SQLITE_STATIC);


### PR DESCRIPTION
My goal is to fix this issue: https://github.com/SRombauts/SQLiteCpp/issues/517

Previous, similar PRs:
 - https://github.com/SRombauts/SQLiteCpp/pull/224 : ambiguous overloads
 - https://github.com/SRombauts/SQLiteCpp/pull/355 : missing C++17 ifdef guards
 
 I should probably add unit tests and examples using string_view.
 
