### PR TITLE
use std namespace for int types under cstdint

### DIFF
--- a/include/SQLiteCpp/Column.h
+++ b/include/SQLiteCpp/Column.h
@@ -75,11 +75,11 @@ public:
 #endif
 
     /// Return the integer value of the column.
-    int32_t     getInt() const noexcept;
+    std::int32_t     getInt() const noexcept;
     /// Return the 32bits unsigned integer value of the column (note that SQLite3 does not support unsigned 64bits).
-    uint32_t    getUInt() const noexcept;
+    std::uint32_t    getUInt() const noexcept;
     /// Return the 64bits integer value of the column (note that SQLite3 does not support unsigned 64bits).
-    int64_t     getInt64() const noexcept;
+    std::int64_t     getInt64() const noexcept;
     /// Return the double (64bits float) value of the column
     double      getDouble() const noexcept;
     /**
@@ -164,31 +164,31 @@ public:
     {
         return static_cast<char>(getInt());
     }
-    operator int8_t() const
+    operator std::int8_t() const
     {
-        return static_cast<int8_t>(getInt());
+        return static_cast<std::int8_t>(getInt());
     }
-    operator uint8_t() const
+    operator std::uint8_t() const
     {
-        return static_cast<uint8_t>(getInt());
+        return static_cast<std::uint8_t>(getInt());
     }
-    operator int16_t() const
+    operator std::int16_t() const
     {
-        return static_cast<int16_t>(getInt());
+        return static_cast<std::int16_t>(getInt());
     }
-    operator uint16_t() const
+    operator std::uint16_t() const
     {
-        return static_cast<uint16_t>(getInt());
+        return static_cast<std::uint16_t>(getInt());
     }
-    operator int32_t() const
+    operator std::int32_t() const
     {
         return getInt();
     }
-    operator uint32_t() const
+    operator std::uint32_t() const
     {
         return getUInt();
     }
-    operator int64_t() const
+    operator std::int64_t() const
     {
         return getInt64();
     }

--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -446,7 +446,7 @@ public:
      *
      * @return Rowid of the most recent successful INSERT into the database, or 0 if there was none.
      */
-    int64_t getLastInsertRowid() const noexcept;
+    std::int64_t getLastInsertRowid() const noexcept;
 
     /// Get number of rows modified by last INSERT, UPDATE or DELETE statement (not DROP table).
     int getChanges() const noexcept;

--- a/include/SQLiteCpp/Statement.h
+++ b/include/SQLiteCpp/Statement.h
@@ -126,15 +126,15 @@ public:
     /**
      * @brief Bind an int value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const int aIndex, const int32_t       aValue);
+    void bind(const int aIndex, const std::int32_t       aValue);
     /**
      * @brief Bind a 32bits unsigned int value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const int aIndex, const uint32_t      aValue);
+    void bind(const int aIndex, const std::uint32_t      aValue);
     /**
      * @brief Bind a 64bits int value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const int aIndex, const int64_t       aValue);
+    void bind(const int aIndex, const std::int64_t       aValue);
     /**
      * @brief Bind a double (64bits float) value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
@@ -194,21 +194,21 @@ public:
     /**
      * @brief Bind an int value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const char* apName, const int32_t         aValue)
+    void bind(const char* apName, const std::int32_t         aValue)
     {
         bind(getIndex(apName), aValue);
     }
     /**
      * @brief Bind a 32bits unsigned int value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const char* apName, const uint32_t        aValue)
+    void bind(const char* apName, const std::uint32_t        aValue)
     {
         bind(getIndex(apName), aValue);
     }
     /**
      * @brief Bind a 64bits int value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const char* apName, const int64_t         aValue)
+    void bind(const char* apName, const std::int64_t         aValue)
     {
         bind(getIndex(apName), aValue);
     }
@@ -295,21 +295,21 @@ public:
     /**
      * @brief Bind an int value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const std::string& aName, const int32_t         aValue)
+    void bind(const std::string& aName, const std::int32_t         aValue)
     {
         bind(aName.c_str(), aValue);
     }
     /**
      * @brief Bind a 32bits unsigned int value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const std::string& aName, const uint32_t        aValue)
+    void bind(const std::string& aName, const std::uint32_t        aValue)
     {
         bind(aName.c_str(), aValue);
     }
     /**
      * @brief Bind a 64bits int value to a named parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement (aIndex >= 1)
      */
-    void bind(const std::string& aName, const int64_t         aValue)
+    void bind(const std::string& aName, const std::int64_t         aValue)
     {
         bind(aName.c_str(), aValue);
     }

--- a/src/Column.cpp
+++ b/src/Column.cpp
@@ -50,19 +50,19 @@ const char* Column::getOriginName() const noexcept
 #endif
 
 // Return the integer value of the column specified by its index starting at 0
-int32_t Column::getInt() const noexcept
+std::int32_t Column::getInt() const noexcept
 {
     return sqlite3_column_int(mStmtPtr.get(), mIndex);
 }
 
 // Return the unsigned integer value of the column specified by its index starting at 0
-uint32_t Column::getUInt() const noexcept
+std::uint32_t Column::getUInt() const noexcept
 {
     return static_cast<unsigned>(getInt64());
 }
 
 // Return the 64bits integer value of the column specified by its index starting at 0
-int64_t Column::getInt64() const noexcept
+std::int64_t Column::getInt64() const noexcept
 {
     return sqlite3_column_int64(mStmtPtr.get(), mIndex);
 }

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -138,7 +138,7 @@ bool Database::tableExists(const char* apTableName) const
 }
 
 // Get the rowid of the most recent successful INSERT into the database from the current connection.
-int64_t Database::getLastInsertRowid() const noexcept
+std::int64_t Database::getLastInsertRowid() const noexcept
 {
     return sqlite3_last_insert_rowid(getHandle());
 }

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -81,21 +81,21 @@ int Statement::getIndex(const char * const apName) const
 }
 
 // Bind an 32bits int value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
-void Statement::bind(const int aIndex, const int32_t aValue)
+void Statement::bind(const int aIndex, const std::int32_t aValue)
 {
     const int ret = sqlite3_bind_int(getPreparedStatement(), aIndex, aValue);
     check(ret);
 }
 
 // Bind a 32bits unsigned int value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
-void Statement::bind(const int aIndex, const uint32_t aValue)
+void Statement::bind(const int aIndex, const std::uint32_t aValue)
 {
     const int ret = sqlite3_bind_int64(getPreparedStatement(), aIndex, aValue);
     check(ret);
 }
 
 // Bind a 64bits int value to a parameter "?", "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
-void Statement::bind(const int aIndex, const int64_t aValue)
+void Statement::bind(const int aIndex, const std::int64_t aValue)
 {
     const int ret = sqlite3_bind_int64(getPreparedStatement(), aIndex, aValue);
     check(ret);

--- a/tests/Column_test.cpp
+++ b/tests/Column_test.cpp
@@ -62,15 +62,15 @@ static void test_column_basis(bool utf16)
 
     // validates every variant of cast operators, and conversions of types
     {
-        const int64_t       id1     = query.getColumn(0); // operator int64_t()
-        const int32_t       id2     = query.getColumn(0); // operator int32_t()
-        const int           id3     = query.getColumn(0); // operator int32_t()
-        const int16_t       id4     = query.getColumn(0); // operator int32_t()
-        const short         id5     = query.getColumn(0); // operator int32_t()
-        const int8_t        id6     = query.getColumn(0); // operator int32_t()
-        const char          id7     = query.getColumn(0); // operator int32_t()
+        const std::int64_t       id1     = query.getColumn(0); // operator std::int64_t()
+        const std::int32_t       id2     = query.getColumn(0); // operator std::int32_t()
+        const int           id3     = query.getColumn(0); // operator std::int32_t()
+        const std::int16_t       id4     = query.getColumn(0); // operator std::int32_t()
+        const short         id5     = query.getColumn(0); // operator std::int32_t()
+        const std::int8_t        id6     = query.getColumn(0); // operator std::int32_t()
+        const char          id7     = query.getColumn(0); // operator std::int32_t()
         const unsigned int  uint1   = query.getColumn(0); // operator unsigned int()
-        const uint32_t      uint2   = query.getColumn(0); // operator unsigned int()
+        const std::uint32_t      uint2   = query.getColumn(0); // operator unsigned int()
         const unsigned char uint3   = query.getColumn(0); // operator unsigned char()
         const unsigned short uint4  = query.getColumn(0); // operator unsigned short()
         const char*         ptxt    = query.getColumn(1); // operator const char*()
@@ -112,9 +112,9 @@ static void test_column_basis(bool utf16)
 
     // validates every variant of explicit getters
     {
-        int64_t             id      = query.getColumn(0).getInt64();
+        std::int64_t             id      = query.getColumn(0).getInt64();
         const unsigned int  uint1   = query.getColumn(0).getUInt();
-        const uint32_t      uint2   = query.getColumn(0).getUInt();
+        const std::uint32_t      uint2   = query.getColumn(0).getUInt();
         const std::string   msg1    = query.getColumn(1).getString();
         const char*         ptxt    = query.getColumn(1).getText();
         const std::string   msg2    = query.getColumn(1).getText();

--- a/tests/Statement_test.cpp
+++ b/tests/Statement_test.cpp
@@ -12,7 +12,7 @@
 #include <SQLiteCpp/Database.h>
 #include <SQLiteCpp/Statement.h>
 
-#include <cstdint>   // for int64_t
+#include <cstdint>   // for std::int64_t
 #include <sqlite3.h> // for SQLITE_DONE
 
 #include <gtest/gtest.h>
@@ -165,10 +165,10 @@ TEST(Statement, executeStep)
     query.executeStep();
     EXPECT_TRUE (query.hasRow());
     EXPECT_FALSE(query.isDone());
-    const int64_t       id      = query.getColumn(0);
+    const std::int64_t       id      = query.getColumn(0);
     const std::string   msg     = query.getColumn(1);
     const int           integer = query.getColumn(2);
-    const int64_t       integer2= query.getColumn(2);
+    const std::int64_t       integer2= query.getColumn(2);
     const double        real    = query.getColumn(3);
     EXPECT_EQ(1,        id);
     EXPECT_EQ("first",  msg);
@@ -218,10 +218,10 @@ TEST(Statement, tryExecuteStep)
     EXPECT_EQ(query.tryExecuteStep(), SQLITE_ROW);
     EXPECT_TRUE (query.hasRow());
     EXPECT_FALSE(query.isDone());
-    const int64_t       id      = query.getColumn(0);
+    const std::int64_t       id      = query.getColumn(0);
     const std::string   msg     = query.getColumn(1);
     const int           integer = query.getColumn(2);
-    const int64_t       integer2= query.getColumn(2);
+    const std::int64_t       integer2= query.getColumn(2);
     const double        real    = query.getColumn(3);
     EXPECT_EQ(1,        id);
     EXPECT_EQ("first",  msg);
@@ -328,7 +328,7 @@ TEST(Statement, bindings)
     // Fourth row with string/int64/float
     {
         const std::string   fourth("fourth");
-        const int64_t       int64 = 12345678900000LL;
+        const std::int64_t       int64 = 12345678900000LL;
         const float         float32 = 0.234f;
         insert.bind(1, fourth);
         insert.bind(2, int64);
@@ -371,10 +371,10 @@ TEST(Statement, bindings)
     // reset() without clearbindings()
     insert.reset();
 
-    // Sixth row with uint32_t unsigned value and a long value (which is either a 32b int or a 64b int64_t)
+    // Sixth row with std::uint32_t unsigned value and a long value (which is either a 32b int or a 64b std::int64_t)
     {
-        const uint32_t  uint32 = 4294967295U;
-        const int64_t   integer = -123;
+        const std::uint32_t  uint32 = 4294967295U;
+        const std::int64_t   integer = -123;
         insert.bind(2, uint32);
         insert.bind(3, integer);
         EXPECT_EQ(1, insert.exec());
@@ -395,7 +395,7 @@ TEST(Statement, bindings)
 
     // Seventh row using another variant of int64 type
     {
-        const int64_t   int64 = 12345678900000LL;
+        const std::int64_t   int64 = 12345678900000LL;
         insert.bind(2, int64);
         EXPECT_EQ(1, insert.exec());
         EXPECT_EQ(SQLITE_DONE, db.getErrorCode());
@@ -492,8 +492,8 @@ TEST(Statement, bindByName)
     // Second row with string/int64/float
     {
         const std::string   second("second");
-        const int32_t       int32 = -123;
-        const int64_t       int64 = 12345678900000LL;
+        const std::int32_t       int32 = -123;
+        const std::int64_t       int64 = 12345678900000LL;
         const float         float32 = 0.234f;
         insert.bind("@msg",      second);
         insert.bind("@int",      int32);
@@ -537,10 +537,10 @@ TEST(Statement, bindByName)
     // reset() without clearbindings()
     insert.reset();
 
-    // Fourth row with uint32_t unsigned value and int64_t 64bits value
+    // Fourth row with std::uint32_t unsigned value and std::int64_t 64bits value
     {
-        const uint32_t  uint32 = 4294967295U;
-        const int64_t   int64 = 12345678900000LL;
+        const std::uint32_t  uint32 = 4294967295U;
+        const std::int64_t   int64 = 12345678900000LL;
         insert.bind("@int", uint32);
         insert.bind("@long", int64);
         EXPECT_EQ(1, insert.exec());
@@ -605,8 +605,8 @@ TEST(Statement, bindByNameString)
     // Second row with string/int64/float
     {
         const std::string   second("second");
-        const int64_t       int64 = 12345678900000LL;
-        const int64_t       integer = -123;
+        const std::int64_t       int64 = 12345678900000LL;
+        const std::int64_t       integer = -123;
         const float         float32 = 0.234f;
         insert.bind(amsg, second);
         insert.bind(aint, int64);
@@ -650,10 +650,10 @@ TEST(Statement, bindByNameString)
     // reset() without clearbindings()
     insert.reset();
 
-    // Fourth row with uint32_t unsigned value and int64_t 64bits value
+    // Fourth row with std::uint32_t unsigned value and std::int64_t 64bits value
     {
-        const uint32_t  uint32 = 4294967295U;
-        const int64_t   int64 = 12345678900000LL;
+        const std::uint32_t  uint32 = 4294967295U;
+        const std::int64_t   int64 = 12345678900000LL;
         insert.bind(aint, uint32);
         insert.bind(along, int64);
         EXPECT_EQ(1, insert.exec());


### PR DESCRIPTION
integer types under `cstdint` are only required to be under the `std` namespace while the global namespace definition is optional.

this PR fixes the undefined behavior for the files that assume global namespace availability.