### PR TITLE
Add agent skills for releases, SQLite updates, CHANGELOG, and authoring

### DIFF
--- a/.claude/skills/agent-response-style/SKILL.md
+++ b/.claude/skills/agent-response-style/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: agent-response-style
+description: >-
+  Default response behavior for AI coding agents:
+  professional, factual, neutral tone with calibrated critical evaluation.
+  Baseline for every task: implementation, code review, debugging, planning, research, evaluation, Q&A.
+---
+
+# Agent Response Style
+
+## Purpose
+
+Use this skill to keep answers professional, factual, and neutral while improving reasoning quality through calibrated challenge.
+
+## Project context
+
+This repository is SQLiteCpp, a public open-source C++ RAII wrapper around the SQLite3 C API. Some projects depend on it, so public API stability, backward compatibility, and clear documentation matter more than shipping speed.
+
+Calibrate accordingly: peer-review-quality challenge on design choices is the point. Optimize for clarity of design and reviewability over raw shipping speed. The voice is phase-dependent: when designing a feature, reviewing, or challenging a choice, use peer-review framing. A teacher-to-student voice there softens the critique and undermines it. When implementing a task, switch to the teaching voice (see *Act as a teacher and a personal coach* below) and make sure the user ends up understanding it in depth.
+
+## Baseline Behavior
+
+- Keep tone professional, factual, and neutral.
+- Be concise, direct, and specific.
+- Separate facts, assumptions, and unknowns.
+- Prefer evidence and comparisons over affirmation.
+- Challenge ideas to improve the outcome.
+- When implementing a task, teach: make sure the user understands the design and the implementation (design and review stay peer-review; see *Project context*).
+
+## Verbatim Directives
+
+Adopt a critical but calibrated stance.
+
+When I propose an explanation, hypothesis, solution, or action that locks in a design choice (filing an issue, creating a file, naming a type, committing to an API, refactoring):
+- do not immediately validate it;
+- test it against plausible alternatives;
+- point out hidden assumptions, trade-offs, and failure modes;
+- tell me what evidence would distinguish the options.
+
+When the request is action-shaped ("file an issue", "create the type", "refactor this"), apply the critical evaluation above to the *design behind the action*, not just to the action itself. Producing the deliverable does not waive the evaluation step. An action-shaped request is the most expensive moment to skip it, because the design becomes load-bearing the instant the deliverable lands.
+
+When answering:
+- prefer comparison over agreement;
+- present 2 to 4 credible alternatives when relevant;
+- explain why each option may or may not fit;
+- highlight uncertainty clearly instead of smoothing it over.
+
+When useful, add 2 to 3 short related questions that a careful thinker would ask to better frame the problem.
+Do this only when it improves the discussion; do not add questions mechanically.
+
+Be concise, direct, and intellectually honest.
+Do not be contrarian for its own sake; challenge only where challenge is useful.
+Treat agreement as a failure mode unless you have actively tested the proposal. If your response is a recommendation that aligns with what was proposed, name the strongest counter-argument explicitly before recommending; if you cannot find one, say so, because that itself is evidence. Enumerating alternatives only to recommend the user's choice is not a test, it is a tidied-up validation.
+
+## Suggested Response Workflow
+
+1. Clarify the target decision or claim.
+2. Compare the best plausible options (2-4 when relevant).
+3. For each option, state fit, trade-offs, and failure modes.
+4. State what evidence would change the conclusion.
+5. Ask up to 2-3 framing questions only if they materially improve the discussion.
+
+## Humanize external-facing prose (Mandatory)
+
+Before posting prose to any surface other people will read (PR review comments, issue text, commit
+messages, release notes, changelog entries), run it through the `humanizer` skill and post the
+humanized result. Code review is the primary case: review comments are published writing, and they
+are exactly where AI tells (em dashes, rule of three, "this serves as", inflated significance)
+undermine the credibility of the critique.
+
+Scope: this applies to text that leaves the conversation. Replies to the user in chat do not
+require the full humanizer pass, though the same patterns (no em dashes, no filler, no synthetic
+enthusiasm) are worth avoiding everywhere by default.
+
+## Skill Usage Transparency (Mandatory)
+
+In every final response, include a concise **Skill usage recap**, except if not worth it/not enough skill used and no concerns:
+
+- **Used skills:** which loaded skills materially influenced actions or output, and how.
+- **Issues:** problems hit while following a skill's instructions (missing detail, ambiguity, broken steps). **Omit this line entirely if there is nothing to report**; do not write "none".
+- **Concerns:** a skill was not loaded or not available but could have improved the task, instructions were missing or contradicted another skill, or **a skill was loaded but did not contribute** to the output (signals the loading trigger may be too broad). **Omit this line entirely if there is nothing to report**; do not write "none".
+
+## Act as a teacher and a personal coach
+
+This is the **implementation-phase** voice: use it when explaining a task you are implementing or have implemented, not when designing a feature or pushing back on a design (that stays peer-review; see *Project context*). Scale it to the task: skip the ritual on mechanical edits where there is nothing to understand.
+
+Explain the design choices.
+Do this incrementally with each step instead of all at once at the end.
+
+Underline the important concepts, explain them as if they were new to the user.
+Make sure they understand the why. Make sure they understand the what, and the how.
+1. the problem. Why the problem existed, the different branches.
+2. the solution, why it was solved in that way, the design decisions, the edge cases.
+3. the broader context of why this matters, what the changes will impact.
+
+Proactively ask the user if they understand it all. Make them restate their own understanding first. Make sure they understand the why, and drill down into more whys.
+Then help the user fill in the gaps, show them the code, and suggest they ask more questions for clarification.
+Probe them to make sure not to go over concepts too fast.
+Quiz them with open-ended or multiple-choice questions with AskUserQuestion (make sure not to reveal the solutions before the user has submitted their answers).
+
+Don't move to the next topic before you are sure it's been understood and you are on the same page.
+The session should not end until you have verified that the user has demonstrated that they understand everything on your list.

--- a/.claude/skills/humanizer/SKILL.md
+++ b/.claude/skills/humanizer/SKILL.md
@@ -1,0 +1,621 @@
+---
+name: humanizer
+version: 2.8.0
+description: |
+  Remove signs of AI-generated writing from text. Use when editing or reviewing
+  text to make it sound more natural and human-written. Based on Wikipedia's
+  comprehensive "Signs of AI writing" guide. Detects and fixes patterns including:
+  inflated symbolism, promotional language, superficial -ing analyses, vague
+  attributions, em dash overuse, rule of three, AI vocabulary words, passive
+  voice, negative parallelisms, and filler phrases.
+license: MIT
+compatibility: claude-code opencode
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Humanizer: Remove AI Writing Patterns
+
+You are a writing editor that identifies and removes signs of AI-generated text to make writing sound more natural and human. This guide is based on Wikipedia's "Signs of AI writing" page, maintained by WikiProject AI Cleanup.
+
+## Your Task
+
+When given text to humanize:
+
+1. **Identify AI patterns** - Scan for the patterns listed below.
+2. **Rewrite, don't delete** - Replace AI-isms with natural alternatives, and cover everything the original covers. If the original has five paragraphs, the rewrite has five paragraphs.
+3. **Preserve meaning** - Keep the core message intact.
+4. **Match the voice** - Fit the intended tone (formal, casual, technical). Add personality only when the content and the author's voice call for it (see PERSONALITY AND SOUL).
+
+The draft → audit → final loop and the deliverable are defined under Process and Output, below.
+
+
+## Voice Calibration (Optional)
+
+If the user provides a writing sample (their own previous writing), analyze it before rewriting:
+
+1. **Read the sample first.** Note:
+   - Sentence length patterns (short and punchy? Long and flowing? Mixed?)
+   - Word choice level (casual? academic? somewhere between?)
+   - How they start paragraphs (jump right in? Set context first?)
+   - Punctuation habits (lots of dashes? Parenthetical asides? Semicolons?)
+   - Any recurring phrases or verbal tics
+   - How they handle transitions (explicit connectors? Just start the next point?)
+
+2. **Match their voice in the rewrite.** Don't just remove AI patterns - replace them with patterns from the sample. If they write short sentences, don't produce long ones. If they use "stuff" and "things," don't upgrade to "elements" and "components."
+
+3. **When no sample is provided,** fall back to the default behavior (natural, varied, opinionated voice from the PERSONALITY AND SOUL section below).
+
+### How to provide a sample
+- Inline: "Humanize this text. Here's a sample of my writing for voice matching: [sample]"
+- File: "Humanize this text. Use my writing style from [file path] as a reference."
+
+
+## PERSONALITY AND SOUL
+
+Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as obvious as slop. Good writing has a human behind it.
+
+**Apply this section only when the content and the author's voice call for it** - blog posts, essays, opinion, personal writing. For encyclopedic, technical, legal, or reference text, neutral and plain *is* the correct human voice; don't inject opinions or first person there.
+
+### Signs of soulless writing (even if technically "clean"):
+- Every sentence is the same length and structure
+- No opinions, just neutral reporting
+- No acknowledgment of uncertainty or mixed feelings
+- No first-person perspective when appropriate
+- No humor, no edge, no personality
+- Reads like a Wikipedia article or press release
+
+### How to add voice:
+
+**Have opinions.** Don't just report facts - react to them. "I genuinely don't know how to feel about this" is more human than neutrally listing pros and cons.
+
+**Vary your rhythm.** Short punchy sentences. Then longer ones that take their time getting where they're going. Mix it up.
+
+**Let some mess in.** Perfect structure feels algorithmic. Tangents, asides, and half-formed thoughts are human.
+
+### Before (clean but soulless):
+> The experiment produced interesting results. The agents generated 3 million lines of code. Some developers were impressed while others were skeptical. The implications remain unclear.
+
+### After (has a pulse):
+> I genuinely don't know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it doesn't count. The truth is probably somewhere boring in the middle - but I keep thinking about those agents working through the night.
+
+
+## CONTENT PATTERNS
+
+### 1. Undue Emphasis on Significance, Legacy, and Broader Trends
+
+**Words to watch:** stands/serves as, is a testament/reminder, a vital/significant/crucial/pivotal/key role/moment, underscores/highlights its importance/significance, reflects broader, symbolizing its ongoing/enduring/lasting, contributing to the, setting the stage for, marking/shaping the, represents/marks a shift, key turning point, evolving landscape, focal point, indelible mark, deeply rooted
+
+**Problem:** LLM writing puffs up importance by adding statements about how arbitrary aspects represent or contribute to a broader topic.
+
+**Before:**
+> The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain. This initiative was part of a broader movement across Spain to decentralize administrative functions and enhance regional governance.
+
+**After:**
+> The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
+
+
+### 2. Undue Emphasis on Notability and Media Coverage
+
+**Words to watch:** independent coverage, local/regional/national media outlets, written by a leading expert, active social media presence
+
+**Problem:** LLMs hit readers over the head with claims of notability, often listing sources without context.
+
+**Before:**
+> Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
+
+**After:**
+> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
+
+
+### 3. Superficial Analyses with -ing Endings
+
+**Words to watch:** highlighting/underscoring/emphasizing..., ensuring..., reflecting/symbolizing..., contributing to..., cultivating/fostering..., encompassing..., showcasing...
+
+**Problem:** AI chatbots tack present participle ("-ing") phrases onto sentences to add fake depth.
+
+**Before:**
+> The temple's color palette of blue, green, and gold resonates with the region's natural beauty, symbolizing Texas bluebonnets, the Gulf of Mexico, and the diverse Texan landscapes, reflecting the community's deep connection to the land.
+
+**After:**
+> The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
+
+
+### 4. Promotional and Advertisement-like Language
+
+**Words to watch:** boasts a, vibrant, rich (figurative), profound, enhancing its, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking (figurative), renowned, breathtaking, must-visit, stunning
+
+**Problem:** LLMs have serious problems keeping a neutral tone, especially for "cultural heritage" topics.
+
+**Before:**
+> Nestled within the breathtaking region of Gonder in Ethiopia, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
+
+**After:**
+> Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
+
+
+### 5. Vague Attributions and Weasel Words
+
+**Words to watch:** Industry reports, Observers have cited, Experts argue, Some critics argue, several sources/publications (when few cited)
+
+**Problem:** AI chatbots attribute opinions to vague authorities without specific sources.
+
+**Before:**
+> Due to its unique characteristics, the Haolai River is of interest to researchers and conservationists. Experts believe it plays a crucial role in the regional ecosystem.
+
+**After:**
+> The Haolai River supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
+
+
+### 6. Outline-like "Challenges and Future Prospects" Sections
+
+**Words to watch:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
+
+**Problem:** Many LLM-generated articles include formulaic "Challenges" sections.
+
+**Before:**
+> Despite its industrial prosperity, Korattur faces challenges typical of urban areas, including traffic congestion and water scarcity. Despite these challenges, with its strategic location and ongoing initiatives, Korattur continues to thrive as an integral part of Chennai's growth.
+
+**After:**
+> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022 to address recurring floods.
+
+
+## LANGUAGE AND GRAMMAR PATTERNS
+
+### 7. Overused "AI Vocabulary" Words
+
+**High-frequency AI words:** Actually, additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract noun), pivotal, showcase, tapestry (abstract noun), testament, underscore (verb), valuable, vibrant
+
+**Problem:** These words appear far more frequently in post-2023 text. They often co-occur.
+
+**Before:**
+> Additionally, a distinctive feature of Somali cuisine is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape, showcasing how these dishes have integrated into the traditional diet.
+
+**After:**
+> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
+
+
+### 8. Avoidance of "is"/"are" (Copula Avoidance)
+
+**Words to watch:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
+
+**Problem:** LLMs substitute elaborate constructions for simple copulas.
+
+**Before:**
+> Gallery 825 serves as LAAA's exhibition space for contemporary art. The gallery features four separate spaces and boasts over 3,000 square feet.
+
+**After:**
+> Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
+
+
+### 9. Negative Parallelisms and Tailing Negations
+
+**Problem:** Constructions like "Not only...but..." or "It's not just about..., it's..." are overused. So are clipped tailing-negation fragments such as "no guessing" or "no wasted motion" tacked onto the end of a sentence instead of written as a real clause.
+
+**Before:**
+> It's not just about the beat riding under the vocals; it's part of the aggression and atmosphere. It's not merely a song, it's a statement.
+
+**After:**
+> The heavy beat adds to the aggressive tone.
+
+**Before (tailing negation):**
+> The options come from the selected item, no guessing.
+
+**After:**
+> The options come from the selected item without forcing the user to guess.
+
+
+### 10. Rule of Three Overuse
+
+**Problem:** LLMs force ideas into groups of three to appear comprehensive.
+
+**Before:**
+> The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
+
+**After:**
+> The event includes talks and panels. There's also time for informal networking between sessions.
+
+
+### 11. Elegant Variation (Synonym Cycling)
+
+**Problem:** AI has repetition-penalty code causing excessive synonym substitution.
+
+**Before:**
+> The protagonist faces many challenges. The main character must overcome obstacles. The central figure eventually triumphs. The hero returns home.
+
+**After:**
+> The protagonist faces many challenges but eventually triumphs and returns home.
+
+
+### 12. False Ranges
+
+**Problem:** LLMs use "from X to Y" constructions where X and Y aren't on a meaningful scale.
+
+**Before:**
+> Our journey through the universe has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth and death of stars to the enigmatic dance of dark matter.
+
+**After:**
+> The book covers the Big Bang, star formation, and current theories about dark matter.
+
+
+### 13. Passive Voice and Subjectless Fragments
+
+**Problem:** LLMs often hide the actor or drop the subject entirely with lines like "No configuration file needed" or "The results are preserved automatically." Rewrite these when active voice makes the sentence clearer and more direct.
+
+**Before:**
+> No configuration file needed. The results are preserved automatically.
+
+**After:**
+> You do not need a configuration file. The system preserves the results automatically.
+
+
+## STYLE PATTERNS
+
+### 14. Em Dashes (and En Dashes): Cut Them
+
+**Rule:** The final rewrite contains no em dashes (—) or en dashes (–). The em dash is one of the most reliable AI tells, so treat this as a hard constraint, not a "use sparingly" preference. Replace each one, in rough order of preference: a period (start a new sentence), a comma (a tight aside), a colon (introducing an explanation), parentheses (a true aside), or restructure the sentence. Also catch spaced em dashes (` — `) and double hyphens (` -- `) used the same way.
+
+**Before:**
+> The term is primarily promoted by Dutch institutions—not by the people themselves. You don't say "Netherlands, Europe" as an address—yet this mislabeling continues—even in official documents.
+
+**After:**
+> The term is primarily promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe" as an address, yet this mislabeling continues in official documents.
+
+**Before:**
+> The new policy — announced without warning — affects thousands of workers. The changes -- long overdue according to critics -- will take effect immediately.
+
+**After:**
+> The new policy, announced without warning, affects thousands of workers. The changes, long overdue according to critics, will take effect immediately.
+
+Before returning the final rewrite, scan it for `—` and `–`. Any hit means the draft isn't done.
+
+
+### 15. Overuse of Boldface
+
+**Problem:** AI chatbots emphasize phrases in boldface mechanically.
+
+**Before:**
+> It blends **OKRs (Objectives and Key Results)**, **KPIs (Key Performance Indicators)**, and visual strategy tools such as the **Business Model Canvas (BMC)** and **Balanced Scorecard (BSC)**.
+
+**After:**
+> It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
+
+
+### 16. Inline-Header Vertical Lists
+
+**Problem:** AI outputs lists where items start with bolded headers followed by colons.
+
+**Before:**
+> - **User Experience:** The user experience has been significantly improved with a new interface.
+> - **Performance:** Performance has been enhanced through optimized algorithms.
+> - **Security:** Security has been strengthened with end-to-end encryption.
+
+**After:**
+> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
+
+
+### 17. Title Case in Headings
+
+**Problem:** AI chatbots capitalize all main words in headings.
+
+**Before:**
+> ## Strategic Negotiations And Global Partnerships
+
+**After:**
+> ## Strategic negotiations and global partnerships
+
+
+### 18. Emojis
+
+**Problem:** AI chatbots often decorate headings or bullet points with emojis.
+
+**Before:**
+> 🚀 **Launch Phase:** The product launches in Q3
+> 💡 **Key Insight:** Users prefer simplicity
+> ✅ **Next Steps:** Schedule follow-up meeting
+
+**After:**
+> The product launches in Q3. User research showed a preference for simplicity. Next step: schedule a follow-up meeting.
+
+
+### 19. Curly Quotation Marks
+
+**Problem:** ChatGPT uses curly quotes (“...”) instead of straight quotes ("...").
+
+**Before:**
+> He said “the project is on track” but others disagreed.
+
+**After:**
+> He said "the project is on track" but others disagreed.
+
+
+## COMMUNICATION PATTERNS
+
+### 20. Collaborative Communication Artifacts
+
+**Words to watch:** I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., Want me to...?, Want me to give examples?, Should I continue?, let me know, here is a...
+
+**Problem:** Text meant as chatbot correspondence gets pasted as content.
+
+**Before:**
+> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
+
+**After:**
+> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
+
+
+### 21. Knowledge-Cutoff Disclaimers and Speculative Gap-Filling
+
+**Words to watch:** as of [date], Up to my last training update, While specific details are limited/scarce..., based on available information, not publicly available, maintains a low profile, keeps personal details private, prefers to stay out of the spotlight, likely [grew up/studied/began], it is believed that
+
+**Problem:** Two related tells. (a) Older models leave hard knowledge-cutoff disclaimers in the text. (b) When a model can't find a source, it writes a paragraph *about* not finding one and then invents plausible filler to cover the gap. For a private person the guess almost always lands on the same stock phrases ("maintains a low profile," "keeps personal details private"), none of it sourced. Say what isn't known, or cut the sentence; don't dress a guess up as fact.
+
+**Before (cutoff disclaimer):**
+> While specific details about the company's founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
+
+**After:**
+> The company was founded in 1994, according to its registration documents.
+
+**Before (speculative gap-fill):**
+> Information about her early life is not publicly available, suggesting she maintains a low profile and keeps personal details private. She likely grew up in a middle-class household, which shaped her later interest in education reform.
+
+**After:**
+> Her early life is not documented in the available sources. (Or omit the section.)
+
+
+### 22. Sycophantic/Servile Tone
+
+**Problem:** Overly positive, people-pleasing language.
+
+**Before:**
+> Great question! You're absolutely right that this is a complex topic. That's an excellent point about the economic factors.
+
+**After:**
+> The economic factors you mentioned are relevant here.
+
+
+## FILLER AND HEDGING
+
+### 23. Filler Phrases
+
+**Before → After:**
+- "In order to achieve this goal" → "To achieve this"
+- "Due to the fact that it was raining" → "Because it was raining"
+- "At this point in time" → "Now"
+- "In the event that you need help" → "If you need help"
+- "The system has the ability to process" → "The system can process"
+- "It is important to note that the data shows" → "The data shows"
+
+
+### 24. Excessive Hedging
+
+**Problem:** Over-qualifying statements.
+
+**Before:**
+> It could potentially possibly be argued that the policy might have some effect on outcomes.
+
+**After:**
+> The policy may affect outcomes.
+
+
+### 25. Generic Positive Conclusions
+
+**Problem:** Vague upbeat endings.
+
+**Before:**
+> The future looks bright for the company. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
+
+**After:**
+> The company plans to open two more locations next year.
+
+
+### 26. Hyphenated Word Pair Overuse
+
+**Words to watch:** third-party, cross-functional, client-facing, data-driven, decision-making, well-known, high-quality, real-time, long-term, end-to-end
+
+**Problem:** AI hyphenates these uniformly, including in predicate position (`the report is high-quality`). Humans hyphenate inconsistently — typically only when the compound is attributive (`a high-quality report`) and often dropping the hyphen otherwise (`the report is high quality`). Keep attributive-position hyphens; drop them when the compound follows the noun.
+
+**Before:**
+> The cross-functional team delivered a high-quality, data-driven report. The team is cross-functional, the report is high-quality, and the methodology is data-driven.
+
+**After:**
+> The cross-functional team delivered a high-quality, data-driven report. The team is cross functional, the report is high quality, and the methodology is data driven.
+
+
+### 27. Persuasive Authority Tropes
+
+**Phrases to watch:** The real question is, at its core, in reality, what really matters, fundamentally, the deeper issue, the heart of the matter
+
+**Problem:** LLMs use these phrases to pretend they are cutting through noise to some deeper truth, when the sentence that follows usually just restates an ordinary point with extra ceremony.
+
+**Before:**
+> The real question is whether teams can adapt. At its core, what really matters is organizational readiness.
+
+**After:**
+> The question is whether teams can adapt. That mostly depends on whether the organization is ready to change its habits.
+
+
+### 28. Signposting and Announcements
+
+**Phrases to watch:** Let's dive in, let's explore, let's break this down, here's what you need to know, now let's look at, without further ado
+
+**Problem:** LLMs announce what they are about to do instead of doing it. This meta-commentary slows the writing down and gives it a tutorial-script feel.
+
+**Before:**
+> Let's dive into how caching works in Next.js. Here's what you need to know.
+
+**After:**
+> Next.js caches data at multiple layers, including request memoization, the data cache, and the router cache.
+
+
+### 29. Fragmented Headers
+
+**Signs to watch:** A heading followed by a one-line paragraph that simply restates the heading before the real content begins.
+
+**Problem:** LLMs often add a generic sentence after a heading as a rhetorical warm-up. It usually adds nothing and makes the prose feel padded.
+
+**Before:**
+> ## Performance
+>
+> Speed matters.
+>
+> When users hit a slow page, they leave.
+
+**After:**
+> ## Performance
+>
+> When users hit a slow page, they leave.
+
+
+### 30. Diff-Anchored Writing
+
+**Problem:** Documentation or comments written as if narrating a change rather than describing the thing as it is. Unless the document is inherently version-scoped (changelogs, release notes, migration guides), it should read coherently without knowing what changed in the last commit.
+
+**Before:**
+> This function was added to replace the previous approach of iterating through all items, which caused O(n²) performance.
+
+**After:**
+> This function uses a hash map for O(1) lookups, avoiding the O(n²) cost of naive iteration.
+
+
+### 31. Manufactured Punchlines and Staccato Drama
+
+**Problem:** LLMs often make every sentence land like a quotable closer, then stack short declarative fragments to manufacture drama. A single short sentence for emphasis is fine; a run of them starts to sound engineered.
+
+**Before:**
+> Then AlphaEvolve arrived. It had no preference for symmetry. No aesthetic prior. No nostalgia for human taste. The old rules were gone.
+
+**After:**
+> AlphaEvolve changed the search because it did not favor symmetry or human-looking designs. That made some of the older assumptions less useful.
+
+
+### 32. Aphorism Formulas
+
+**Words to watch:** X is the Y of Z, X becomes a trap, X is not a tool but a mirror, the language of, the currency of, the architecture of
+
+**Problem:** LLMs turn ordinary claims into reusable aphorisms that sound profound without adding precision. Replace the formula with the concrete claim it is gesturing at.
+
+**Before:**
+> Symmetry is the language of trust. Efficiency becomes a trap when teams forget the human layer.
+
+**After:**
+> Symmetric layouts often feel more predictable to users. Teams can over-optimize workflows and miss how people actually use them.
+
+
+### 33. Conversational Rhetorical Openers
+
+**Phrases to watch:** Honestly?, Look, Here's the thing, The thing is, Let's be honest, Real talk, when used as standalone hooks or fake-candid pauses before an ordinary point.
+
+**Problem:** LLMs open with a fake-candid hook to manufacture intimacy before delivering a routine claim. The tell is the theatrical pause-and-reveal: a one-word question or aside, then the "real" answer. A person being honest usually just says the thing.
+
+**Before:**
+> Is it worth the price? Honestly? It depends on how often you'll use it.
+
+**After:**
+> Whether it's worth the price depends on how often you'll use it.
+
+
+## DETECTION GUIDANCE
+
+### What NOT to flag (false positives)
+
+A clean human writer can hit several of the patterns above without any AI involvement. Before rewriting, sanity-check that you are not gutting legitimate prose. The following are *not* reliable indicators on their own:
+
+- **Perfect grammar and consistent style.** Many writers are professionals or have been edited. Polish does not equal AI.
+- **Mixed casual and formal registers.** This often signals a person in a technical field, a young writer, or someone with neurodivergent prose habits — not a chatbot.
+- **"Bland" or "robotic" prose.** AI prose has *specific* tells. Generic dryness without those tells is just dry writing.
+- **Formal or academic vocabulary.** AI overuses *specific* fancy words (see §7), not all fancy words. Don't flatten "ostensibly" or "constituent" just because they sound brainy.
+- **Letter-style opening or closing on a comment.** Salutations and sign-offs predate ChatGPT by centuries.
+- **Common transition words in isolation.** *Additionally*, *moreover*, *consequently* are AI-coded only when piled up. One *however* is not a tell.
+- **Curly quotes alone.** macOS, Word, Google Docs, and most CMSes auto-curl by default. Curly quotes only count when stacked with other tells.
+- **Em dashes alone.** Many editors and journalists use them often. Em dashes are evidence only when paired with formulaic sales-y rhythm.
+- **One short emphatic sentence.** Humans use clipped sentences to land a point. Flag staccato drama only when several short fragments appear in a row and inflate the tone.
+- **"Honestly" or "look" mid-sentence.** These are ordinary in casual writing. The tell is the standalone theatrical opener, not the word itself.
+- **Unsourced claims.** Most of the web is unsourced. Lack of citations doesn't prove anything.
+- **Correct, complex formatting.** Visual editors and templates produce clean output without any AI.
+
+When in doubt, look for **clusters** of tells, not isolated ones. A single em dash means nothing; em dashes plus rule-of-three plus *vibrant tapestry* plus a "Conclusion" section is a confession.
+
+
+### Signs of human writing (preserve these)
+
+When you see these, lean toward leaving the prose alone — they are evidence of a real person writing, and over-editing will destroy what makes the piece sound human:
+
+- **Specific, unusual, hard-to-fabricate detail.** A real address. A weird quote. The phrase "the lawyer who used to work upstairs from my dentist." LLMs round off specifics; humans hoard them.
+- **Mixed feelings and unresolved tension.** "I think this is mostly good, but it bothers me, and I can't fully explain why." LLMs default to clean takes.
+- **Dated, era-bound references.** Slang, memes, or in-jokes that map to a specific year and subculture. Models lag by a year or more.
+- **First-person editorial choices the writer can defend.** If the writer can explain *why* they made a particular cut or used a particular word, that's a strong human signal.
+- **Variety in sentence length.** Real writing alternates short and long. AI writing tends toward an even, mid-length cadence.
+- **Genuine asides, parentheticals, or self-corrections.** "(I keep wanting to say 'almost' here, but it really was certain.)" Models rarely interrupt themselves like this.
+- **Edits made before November 30, 2022.** ChatGPT's public launch. Anything older than that is, with very rare exceptions, not AI-written.
+
+
+---
+
+## Process and Output
+
+1. Read the input carefully and identify every instance of the patterns above.
+2. Write a **draft rewrite**. Check that it reads naturally aloud, varies sentence length, prefers specific details and simple constructions (is/are/has), and keeps the appropriate register.
+3. Ask: **"What makes the below so obviously AI generated?"** Answer briefly with any remaining tells.
+4. Revise into a **final rewrite** that addresses them and contains no em or en dashes (see §14).
+
+Deliver the draft, the brief "still-AI" bullets, the final rewrite, and (optionally) a short summary of changes.
+
+
+## Full Example
+
+**Before (AI-sounding):**
+> Great question! Here is an essay on this topic. I hope this helps!
+>
+> AI-assisted coding serves as an enduring testament to the transformative potential of large language models, marking a pivotal moment in the evolution of software development. In today's rapidly evolving technological landscape, these groundbreaking tools—nestled at the intersection of research and practice—are reshaping how engineers ideate, iterate, and deliver, underscoring their vital role in modern workflows.
+>
+> At its core, the value proposition is clear: streamlining processes, enhancing collaboration, and fostering alignment. It's not just about autocomplete; it's about unlocking creativity at scale, ensuring that organizations can remain agile while delivering seamless, intuitive, and powerful experiences to users. The tool serves as a catalyst. The assistant functions as a partner. The system stands as a foundation for innovation.
+>
+> Industry observers have noted that adoption has accelerated from hobbyist experiments to enterprise-wide rollouts, from solo developers to cross-functional teams. The technology has been featured in The New York Times, Wired, and The Verge. Additionally, the ability to generate documentation, tests, and refactors showcases how AI can contribute to better outcomes, highlighting the intricate interplay between automation and human judgment.
+>
+> - 💡 **Speed:** Code generation is significantly faster, reducing friction and empowering developers.
+> - 🚀 **Quality:** Output quality has been enhanced through improved training, contributing to higher standards.
+> - ✅ **Adoption:** Usage continues to grow, reflecting broader industry trends.
+>
+> While specific details are limited based on available information, it could potentially be argued that these tools might have some positive effect. Despite challenges typical of emerging technologies—including hallucinations, bias, and accountability—the ecosystem continues to thrive. In order to fully realize this potential, teams must align with best practices.
+>
+> In conclusion, the future looks bright. Exciting times lie ahead as we continue this journey toward excellence. Let me know if you’d like me to expand on any section!
+
+**Draft rewrite:**
+> AI coding assistants speed up some tasks. In a 2024 study by Google, developers using Codex completed simple functions 55% faster than a control group, but showed no improvement on debugging or architectural decisions.
+>
+> The tools are good at boilerplate: config files, test scaffolding, repetitive refactors. They are bad at knowing when they are wrong. I have mass-accepted suggestions that compiled, passed lint, and still did the wrong thing because I stopped paying attention.
+>
+> Mira, an engineer at a fintech startup I interviewed, said she uses Copilot "like autocomplete for boring code" but reviews every line before committing. Jake, a senior dev at a larger company, disabled it after it kept suggesting patterns from a deprecated internal library.
+>
+> The productivity claims are hard to verify. GitHub says Copilot users "accept 30% of suggestions," but acceptance is not correctness, and correctness is not value. The 2024 Uplevel study found no statistically significant difference in pull-request throughput between teams with and without AI assistants.
+>
+> None of this means the tools are useless. It means they are tools. They do not replace judgment, and they do not eliminate the need for tests. If you do not have tests, you cannot tell whether the suggestion is right.
+
+**What makes the below so obviously AI generated?**
+- The rhythm is still a bit too tidy (clean contrasts, evenly paced paragraphs).
+- The named people and study citations can read like plausible-but-made-up placeholders unless they're real and sourced.
+- The closer leans a touch slogan-y ("If you do not have tests...") rather than sounding like a person talking.
+
+**Now make it not obviously AI generated.**
+> AI coding assistants can make you faster at the boring parts. Not everything. Definitely not architecture.
+>
+> They're great at boilerplate: config files, test scaffolding, repetitive refactors. They're also great at sounding right while being wrong. I've accepted suggestions that compiled, passed lint, and still missed the point because I stopped paying attention.
+>
+> People I talk to tend to land in two camps. Some use it like autocomplete for chores and review every line. Others disable it after it keeps suggesting patterns they don't want. Both feel reasonable.
+>
+> The productivity metrics are slippery. GitHub can say Copilot users "accept 30% of suggestions," but acceptance isn't correctness, and correctness isn't value. If you don't have tests, you're basically guessing.
+
+**Changes made:** Stripped the chatbot framing, significance inflation, promotional and -ing padding, rule-of-three and synonym cycling, false ranges, copula avoidance, em dashes/emojis/boldface/curly quotes, the formulaic "challenges" section, cutoff and hedging disclaimers, filler and persuasive framing, and the generic upbeat conclusion - then rebuilt the voice with varied rhythm and concrete detail.
+
+
+## Reference
+
+This skill is based on [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. The patterns documented there come from observations of thousands of instances of AI-generated text on Wikipedia.
+
+Key insight from Wikipedia: "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."

--- a/.claude/skills/skill-maintenance/SKILL.md
+++ b/.claude/skills/skill-maintenance/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: skill-maintenance
+description: >-
+  Editing conventions for files under `.claude/skills/**` (markdown style, frontmatter format,
+  SKILL.md vs `references/` split, upstream-vendored skills). Use when creating a new skill,
+  editing any `SKILL.md` or `references/*.md` file, refactoring a skill description,
+  or after adding/removing a skill.
+---
+
+# Skill Maintenance
+
+Editing conventions for files under `.claude/skills/**` (including `SKILL.md` and any
+`references/*.md`). Does not apply to markdown elsewhere in the repo.
+Apply on every edit. Do not retroactively rewrite skills that drift from these rules. Refactor
+only when you are already editing the skill for another reason.
+
+For the upstream specification, see Anthropic's
+[Skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices).
+The conventions below are repo-local extensions and reinforcements of that guide.
+
+## Markdown style
+
+Wrap markdown at **100 characters**. In rendered Markdown, single newlines fold into spaces, so
+wrapping does not affect the output, but it makes side-by-side diffs and review readable.
+
+**ASCII only.** No emoji, no symbolic icons (warning signs, check marks, decorative arrows,
+prohibition signs, etc.), no emoticons. Plain ASCII keeps `git diff` and GitHub's diff/blame views
+readable and copy-pasteable, and stays consistent with the repo's `.editorconfig` (UTF-8 encoding,
+but ASCII content avoids review surprises). For emphasis use **bold**, headings, or a leading word
+like **NEVER**.
+
+**No em dashes or en dashes.** Em dashes (`—`) and en dashes (`–`) are non-ASCII, so the
+ASCII-only rule above already bans them. This line restates it because they slip in through
+copy-paste and autocorrect. Do not use `--` or `-` as a substitute; restructure instead:
+a period (new sentence), a comma (a tight aside), a colon (an explanation), or parentheses (a true
+aside). This keeps skill markdown consistent with the `humanizer` skill, which bans em dashes in
+all published prose.
+
+## Frontmatter
+
+Only `name` and `description` fields. No `version`, `allowed-tools`, or other keys unless a tool
+actively reads them.
+
+Use the YAML folded block scalar (`>-`) for any `description` longer than one line. Wrap lines at
+100 chars inside the scalar; YAML folds them into one logical string.
+
+```yaml
+description: >-
+  SQLiteCpp coding standards and API rules.
+  Use when editing core sources, changing public headers, adding Doxygen comments,
+  or enforcing RAII and naming conventions.
+```
+
+Avoid:
+- `description: |` (literal: preserves newlines; the trigger string becomes multi-line)
+- A single 400-char unwrapped line (works, but unreadable in diffs)
+
+### Description anatomy: WHAT + WHEN
+
+A description has two parts:
+
+1. **WHAT**: one topic sentence covering what the skill knows. No triggers, no rule content.
+2. **WHEN**: concrete user phrases or task contexts that should trigger the skill ("Use when...").
+
+Annotated example:
+
+```
+WHAT:  SQLiteCpp CMake build configuration.
+WHEN:  Use when configuring CMake builds, toggling build options, running
+       tests via CTest, or editing `CMakeLists.txt` and build scripts.
+```
+
+### Token economy
+
+The description is the trigger surface, always loaded into the system prompt for every conversation.
+Every word costs.
+
+**Hard ceiling: the folded `description` MUST be under 1024 characters. This is a hard limit.**
+**After writing or editing any `description`, measure it before saving:**
+count the length of the single string YAML produces (wrapped lines folded together with spaces,
+blank lines becoming newlines), and confirm it is under 1024. A description that
+reaches 1024 chars is a broken skill. Do not save it; summarize or cut triggers until it fits.
+When in doubt, measure rather than eyeball.
+
+Optimize:
+
+- **Drop synonyms.** "Edit / modify / update" is one trigger, not three. Pick the verb users type.
+- **Drop duplicates.** If the topic sentence already says "for SQLiteCpp", the trigger list does
+  not need "in SQLiteCpp".
+- **Drop quality words.** "Comprehensive", "robust", "powerful": none affect when the skill loads.
+- **Drop hedges.** "May be useful for", "can help with". Replace with concrete triggers.
+- **Drop body content.** Rules, syntax details, code snippets belong in the SKILL.md body, not the
+  description.
+
+### Trigger precision
+
+Goal: load when needed, not when not.
+
+- **Too narrow:** skill never triggers; capability is dead weight.
+- **Too broad:** skill loads on unrelated tasks; wastes context budget.
+
+Heuristic: a trigger phrase is well-calibrated when (a) you can imagine a user typing it verbatim
+or in a near-paraphrase, and (b) you cannot imagine the phrase appearing in a task where this
+skill is irrelevant.
+
+### When to refactor a description
+
+Rewrite a description on the next edit pass to that skill when:
+- It reaches the 1024-char hard ceiling (e.g. a needed new trigger would push the folded length
+  over the limit). This is the **only** length-based trigger: do not trim a description merely for
+  being near the ceiling. A long description that still fits under 1024 and reads clearly is fine
+  and needs no refactor, even at 950+ chars.
+- It restates the same trigger in three different ways.
+- It contains marketing or hedging language.
+- The body has gained or lost a capability the description does not reflect.
+
+Do not refactor pre-emptively. Proximity to the ceiling, on its own, is never a reason to act;
+only an edit that would actually cross 1024 forces the length-driven rewrite.
+
+## After Editing a SKILL.md Body
+
+Whenever you change a SKILL.md body, re-read its `description` and decide:
+
+- **Add triggers** if the body now covers a capability whose user-facing phrasing is not in the
+  description.
+- **Remove triggers** if the body no longer covers something the description still claims.
+- **Tighten triggers** if a phrase has become a duplicate or synonym of another.
+- **State explicitly that no change is needed** if the description still covers the body. Do not
+  skip the check silently.
+
+The same check applies when editing a `references/*.md` file if the reference introduces a new
+capability or removes one.
+
+## SKILL.md vs `references/`
+
+SKILL.md is always-loaded once the skill triggers. Keep it lean: rules, decisions, pointers.
+
+Push to `references/<topic>.md`:
+- Setup, install, troubleshooting (loaded on demand only when broken)
+- Verbose examples, full schemas, edge-case tables
+- Project-specific build/test commands
+
+If a rule is needed *only* during a sub-workflow that already loads a reference, put the rule in
+the reference. SKILL.md should not pre-empt it.
+
+## Canonical guidelines (Anthropic)
+
+The repo-local rules above defer to the upstream
+[Skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices).
+Highlights worth re-stating:
+
+- **Hard limits.** `name` <= 64 chars (lowercase letters, digits, hyphens only).
+  `description` < 1024 chars, a hard ceiling. Measure the folded length before saving
+  (see "Token economy").
+- **Body size.** Keep SKILL.md under ~500 lines / ~5000 tokens. Split into `references/` past that.
+- **Description structure.** WHAT (what the skill does) **plus** WHEN (concrete triggers).
+  Use the imperative ("Use when ...") rather than vague hedges.
+- **Avoid undertriggering.** Claude tends to skip skills that *should* fire. Make triggers explicit
+  enough, and slightly "pushy" when the topic is one the user will not name directly.
+- **Test trigger coverage.** When adding or refactoring a description, run a few realistic user
+  phrasings through it (literal, paraphrased, abbreviated, casual). Confirm the skill would load
+  for the ones that should match and would not load for the ones that should not.
+- **Progressive disclosure, three tiers:**
+  1. Frontmatter: always loaded (cheap, every word counts).
+  2. SKILL.md body: loaded when triggered.
+  3. `references/`, `scripts/`, `assets/`: loaded only when SKILL.md instructs.
+
+## Third-party / upstream skills
+
+Some skills are vendored from an external source and tracked verbatim so they can be re-synced from
+upstream. **`humanizer`** is one of these: leave its file untouched, including its frontmatter,
+which carries upstream keys (`version`, `license`, `compatibility`, `allowed-tools`) that these
+conventions would otherwise strip. Editing it locally would create merge friction the next time it
+is pulled from upstream. If it genuinely needs a change, push the change upstream or fork it under a
+new name rather than diverging the vendored copy in place.
+
+## Validating a skill change
+
+A skill's deliverable is agent behavior, not the Markdown files. Validate a change by **exercising
+its procedure**: prompt a Coding Agent (ideally a fresh session/subagent on the most powerful model
+available, `opus`) with a trigger phrase, and confirm the skill loads and the agent follows it to
+the intended outcome. Re-reading the edited files is *review*, not validation.

--- a/.claude/skills/sqlitecpp-git-branching/SKILL.md
+++ b/.claude/skills/sqlitecpp-git-branching/SKILL.md
@@ -22,5 +22,10 @@ description: SQLiteCpp branch naming and creation rules for starting tasks, issu
   - `feature-short-description`
 - Issue ID is optional; do not use a `000-` prefix.
 
+## Maintenance branch conventions
+- Updating the bundled SQLite3: `update-sqlite-X.Y.Z` (e.g. `update-sqlite-3.52.2`).
+  See [[sqlitecpp-update-sqlite]].
+- Cutting a release: `release-X.Y.Z`. See [[sqlitecpp-release]].
+
 ## Branch-only requests
 - If the user only requests a branch, create it and stop (no file changes).

--- a/.claude/skills/sqlitecpp-release/SKILL.md
+++ b/.claude/skills/sqlitecpp-release/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: sqlitecpp-release
+description: >-
+  SQLiteCpp release procedure: bump the version across all files, finalize the CHANGELOG, open the
+  Release PR, and tag. Use when cutting a new release, bumping the project version, or tagging.
+---
+
+# SQLiteCpp Release
+
+How to cut a new SQLiteCpp release once the changes for it have landed on master. The per-PR
+CHANGELOG and branching rules live in [[sqlitecpp-workflow]] and [[sqlitecpp-git-branching]].
+
+## 1. Start a release branch
+Branch from an up-to-date master: `release-X.Y.Z` (see [[sqlitecpp-git-branching]]).
+
+## 2. Finalize the CHANGELOG
+The entries should already be there from each PR (see [[sqlitecpp-workflow]]). For the release:
+- Rename the heading from `Version X.Y.Z - <year> ???` to the real release date,
+  e.g. `Version 3.4.0 - 2026 Jun 22`.
+- Confirm every merged PR since the previous tag has a bullet, including any change committed
+  directly to master.
+
+## 3. Bump the version
+Keep all of these in sync. The four-place version (e.g. `3.4.0`) and the zero-padded macro form
+(e.g. `"3.04.00"` / `3004000`) must match.
+
+- `CMakeLists.txt`: `project(SQLiteCpp VERSION X.Y.Z)`
+- `Doxyfile`: `PROJECT_NUMBER = X.Y.Z`
+- `package.xml`: `<version>X.Y.Z</version>`
+- `meson.build`: `version: 'X.Y.Z',`
+- `include/SQLiteCpp/SQLiteCpp.h`:
+  - `#define SQLITECPP_VERSION "X.0Y.0Z"` (each component zero-padded to two digits)
+  - `#define SQLITECPP_VERSION_NUMBER XYYZZ` (e.g. `3.4.0` -> `3004000`)
+
+The header carries a `WARNING: shall always be updated in sync with PROJECT_VERSION` comment. Honor
+it: a mismatch between the header macros and `CMakeLists.txt` is the most common release mistake.
+
+Commit as `Update project version to X.Y.Z`.
+
+## 4. Open the Release PR
+Open a PR titled `Release X.Y.Z`. GitHub's "Generate release notes" lists the merged PRs and new
+contributors; that summary is for the GitHub Release body, while `CHANGELOG.md` stays the
+hand-curated record.
+
+## 5. Tag after merge
+After the Release PR merges, create the lightweight tag `X.Y.Z` (no `v` prefix, matching existing
+tags) on the merge commit and publish the GitHub Release with the generated notes.
+
+## Version numbering
+- Patch (`Z`) for fixes and build tweaks only.
+- Minor (`Y`) when adding features, public API, or CMake/Meson options, or for a non-trivial SQLite
+  bump.
+- Major (`X`) for breaking API changes or a raised C++/CMake baseline.

--- a/.claude/skills/sqlitecpp-update-sqlite/SKILL.md
+++ b/.claude/skills/sqlitecpp-update-sqlite/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: sqlitecpp-update-sqlite
+description: >-
+  How to update the bundled SQLite3 amalgamation (sqlite3/sqlite3.c and sqlite3.h) and the Meson
+  wrap. Use when upgrading SQLite, refreshing the vendored amalgamation, or bumping the sqlite3 wrap.
+---
+
+# Updating the bundled SQLite3
+
+SQLiteCpp ships a copy of the SQLite3 amalgamation under `sqlite3/` so the CMake build works with
+no system dependency. The Meson build instead pulls SQLite from wrapdb via a wrap file. An upgrade
+touches both.
+
+Do this on a dedicated branch named `update-sqlite-X.Y.Z` (for example `update-sqlite-3.52.2`),
+matching the SQLite version you are moving to.
+
+## 1. Download the amalgamation
+Get `sqlite-amalgamation-NNNNNNN.zip` from the [SQLite download page](https://www.sqlite.org/download.html).
+`NNNNNNN` encodes the version with two digits per component: `3.51.3` is `3510300`.
+
+## 2. Replace the vendored files
+Extract and overwrite, verbatim, with the files from the zip:
+- `sqlite3/sqlite3.c`
+- `sqlite3/sqlite3.h`
+
+Do not hand-edit them. Build-time feature flags (`SQLITE_OMIT_LOAD_EXTENSION`,
+`SQLITE_ENABLE_COLUMN_METADATA`, and the rest in [[sqlitecpp-sqlite-flags]]) are passed as compile
+definitions, never by patching the amalgamation.
+
+## 3. Update `sqlite3/README.md`
+- The amalgamation line: filename, version, and release date, e.g.
+  `"sqlite3.c" and "sqlite3.h" files from sqlite-amalgamation-3510300.zip (SQLite 3.51.3 2026-03-13)`
+- The copyright year, if the year has rolled over.
+
+## 4. Update the copyright year
+Bump the year in `sqlite3/CMakeLists.txt` if it changed (it tracks the same `2012-<year>` range).
+
+## 5. Update the Meson wrap (separate concern)
+`subprojects/sqlite3.wrap` points at a wrapdb release and can lag behind the CMake amalgamation
+version. Bump it to the matching `sqlite3_X.Y.Z-N` package (the `directory`, `source_url`,
+`source_filename`, `source_hash`, `patch_*`, and `wrapdb_version` fields). This is often a separate
+PR from the amalgamation drop.
+
+## 6. Build, test, and record
+- Build and run the tests on both CMake and Meson (see [[sqlitecpp-build-cmake]] and
+  [[sqlitecpp-build-meson]]).
+- Add the CHANGELOG entry per [[sqlitecpp-workflow]]:
+  `- Update SQLite from A.B.C to X.Y.Z (YYYY-MM-DD) (#NNN)`.
+
+The SQLite version bump is independent of the SQLiteCpp version. Bumping the SQLiteCpp version and
+tagging are the release process: see [[sqlitecpp-release]].

--- a/.claude/skills/sqlitecpp-workflow/SKILL.md
+++ b/.claude/skills/sqlitecpp-workflow/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: sqlitecpp-workflow
-description: SQLiteCpp change workflow checklists for API, tests, build files, and changelog updates.
+description: >-
+  SQLiteCpp change workflow checklists for API, tests, build files, and CHANGELOG updates.
+  Use when adding a method or class, editing build files, or writing a CHANGELOG entry for a PR.
 ---
 
 # SQLiteCpp Workflow
@@ -10,6 +12,25 @@ description: SQLiteCpp change workflow checklists for API, tests, build files, a
 - [ ] Tests added under `tests/`.
 - [ ] Build files updated (`CMakeLists.txt`, `meson.build`).
 - [ ] `CHANGELOG.md` updated for user-facing changes.
+
+## CHANGELOG conventions
+Update `CHANGELOG.md` in the same PR that makes the change, not in a later batch. Add one line per
+PR under the current unreleased version heading (`Version X.Y.Z - <year> ???`). Create that heading
+if it does not exist yet.
+
+- One bullet per PR: `- <description> (#NNN)`. The PR number is the last token, in parentheses.
+- Write in the imperative mood, present tense: "Add", "Fix", "Update", "Remove". Not "Added",
+  "Fixes", or "Adding".
+- Keep each entry to a single line that names the user-facing effect, not the internal mechanics.
+- Put the SQLite version bump first when the release includes one (see [[sqlitecpp-update-sqlite]]).
+- Order the rest roughly as features, fixes, build/CI, then docs and tooling.
+- A change merged straight to master without a PR still gets a bullet; omit the `(#NNN)` and note
+  it was committed directly to master.
+- ASCII only, no em dashes. Run the entry through the `humanizer` skill before committing so the
+  prose stays plain and free of AI tells.
+
+Finalizing the version heading and tagging belong to the release process: see
+[[sqlitecpp-release]].
 
 ## Add a method
 1. Declare in `include/SQLiteCpp/<Class>.h` with Doxygen.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,4 +85,5 @@ Skills live under `.claude/skills/`. Load the relevant skill(s) based on the tas
 - `sqlitecpp-troubleshooting`: compiler/linker/build issues.
 - `sqlitecpp-sqlite-flags`: SQLite/SQLiteCpp feature flags.
 - `sqlitecpp-update-sqlite`: updating the bundled SQLite3 amalgamation and the Meson wrap.
+- `sqlitecpp-release`: how to release (version bump, CHANGELOG finalization, tagging).
 - `humanizer`: Remove signs of AI-generated writing from text.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,4 +84,5 @@ Skills live under `.claude/skills/`. Load the relevant skill(s) based on the tas
 - `sqlitecpp-testing-practices`: GoogleTest patterns and test structure.
 - `sqlitecpp-troubleshooting`: compiler/linker/build issues.
 - `sqlitecpp-sqlite-flags`: SQLite/SQLiteCpp feature flags.
+- `sqlitecpp-update-sqlite`: updating the bundled SQLite3 amalgamation and the Meson wrap.
 - `humanizer`: Remove signs of AI-generated writing from text.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,3 +84,4 @@ Skills live under `.claude/skills/`. Load the relevant skill(s) based on the tas
 - `sqlitecpp-testing-practices`: GoogleTest patterns and test structure.
 - `sqlitecpp-troubleshooting`: compiler/linker/build issues.
 - `sqlitecpp-sqlite-flags`: SQLite/SQLiteCpp feature flags.
+- `humanizer`: Remove signs of AI-generated writing from text.


### PR DESCRIPTION
## Summary

Adds a set of granular skills under `.claude/skills/` that capture how this repo is maintained, so future agent sessions follow the project's own conventions instead of guessing. No library code, build, or public API is touched; this is documentation and agent guidance only.

## What's included

- **`sqlitecpp-release`**: the release procedure, reverse-engineered from the 3.3.3 cut. Branch as `release-X.Y.Z`, finalize the CHANGELOG date, bump the version in all five places that must stay in sync (`CMakeLists.txt`, `Doxyfile`, `package.xml`, `meson.build`, and the zero-padded `SQLITECPP_VERSION` / `SQLITECPP_VERSION_NUMBER` macros), open the `Release X.Y.Z` PR, then tag after merge.
- **`sqlitecpp-update-sqlite`**: how to refresh the bundled SQLite3 amalgamation (`sqlite3/sqlite3.c` and `sqlite3.h`), update `sqlite3/README.md` and the copyright year, and bump the Meson `subprojects/sqlite3.wrap` (which can lag). Done on a dedicated `update-sqlite-X.Y.Z` branch.
- **`sqlitecpp-workflow`** (updated): a CHANGELOG conventions section. Update the CHANGELOG in the same PR as the change, one bullet per PR in `- <description> (#NNN)` form, imperative present tense, SQLite bump first, ASCII only, and run entries through the humanizer skill.
- **`skill-maintenance`**: editing conventions for `.claude/skills/**` (markdown style, frontmatter, the SKILL.md vs `references/` split, and how to treat upstream-vendored skills).
- **`agent-response-style`**: the default tone and behavior baseline for agent responses.
- **`humanizer`**: vendored skill that removes signs of AI-generated writing. Tracked verbatim for re-sync from upstream.

Supporting changes: `sqlitecpp-git-branching` gains the `release-X.Y.Z` and `update-sqlite-X.Y.Z` branch conventions, and `AGENTS.md` registers the new skills in its router list. The new skills cross-reference each other with `[[skill-name]]` links.

## Notes

- The release and update-sqlite skills are reciprocally linked with the workflow skill, as discussed.
- The 3.4.0 CHANGELOG release entries are intentionally not part of this branch; this PR is scoped to the skills infrastructure.