### PR TITLE
Fix Windows MSVC CI: switch generator to Visual Studio 18 2026

### DIFF
--- a/.claude/skills/sqlitecpp-build-cmake/SKILL.md
+++ b/.claude/skills/sqlitecpp-build-cmake/SKILL.md
@@ -6,10 +6,10 @@ description: Build SQLiteCpp with CMake. Use for CMake builds, tests, options, o
 # SQLiteCpp CMake Build
 
 ## Quick builds
-- Windows (VS 2022):
+- Windows (VS 2026):
   - `mkdir build`
   - `cd build`
-  - `cmake -G "Visual Studio 17 2022" -DSQLITECPP_BUILD_TESTS=ON -DSQLITECPP_BUILD_EXAMPLES=ON ..`
+  - `cmake -G "Visual Studio 18 2026" -DSQLITECPP_BUILD_TESTS=ON -DSQLITECPP_BUILD_EXAMPLES=ON ..`
   - `cmake --build . --config Release`
 - Unix/macOS:
   - `mkdir build && cd build`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,11 +63,11 @@ git checkout -b 123-fix-short-description origin/master
 
 ## Build and Test
 ### Quick Build Commands
-**Windows (Visual Studio 2022):**
+**Windows (Visual Studio 2026):**
 ```batch
 mkdir build
 cd build
-cmake -G "Visual Studio 17 2022" -DSQLITECPP_BUILD_TESTS=ON -DSQLITECPP_BUILD_EXAMPLES=ON ..
+cmake -G "Visual Studio 18 2026" -DSQLITECPP_BUILD_TESTS=ON -DSQLITECPP_BUILD_EXAMPLES=ON ..
 cmake --build . --config Release
 ```
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,7 +13,7 @@ jobs:
         - {
             name: "Windows Latest MSVC",
             os: windows-latest,
-            generator: "Visual Studio 17 2022",
+            generator: "Visual Studio 18 2026",
             build_type: "Debug",
             cc: "cl", cxx: "cl",
             extra_path: "",

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Now requires a C++11 compiler. Use branch [sqlitecpp-2.x](https://github.com/SRo
 
 Developments and tests are done under the following OSs:
 - Ubuntu 14.04, 16.04 and 18.04 (Travis CI and Github Actions)
-- Windows 10, and Windows Server 2012 R2, Windows Server 2016, Windows Server 2022 (AppVeyor and Github Actions)
+- Windows 10, and Windows Server 2012 R2, Windows Server 2016, Windows Server 2022, Windows Server 2025 (AppVeyor and Github Actions)
 - MacOS 10.11 and 11.7 (Travis CI and Github Actions)
 - Valgrind memcheck tool
 
@@ -78,7 +78,7 @@ And the following IDEs/Compilers
 - Clang 5 and 7 (Travis CI)
 - AppleClang 8, 9 and 13 (Travis CI and Github Actions)
 - Xcode 8 & 9 (Travis CI)
-- Visual Studio Community/Entreprise 2022, 2019, 2017, and 2015 (AppVeyor and Github Actions)
+- Visual Studio Community/Entreprise 2026, 2022, 2019, 2017, and 2015 (AppVeyor and Github Actions)
 
 ### Dependencies
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,7 @@ Now requires a C++11 compiler. Use branch [sqlitecpp-2.x](https://github.com/SRo
 
 Developments and tests are done under the following OSs:
 - Ubuntu 14.04, 16.04 and 18.04 (Travis CI and Github Actions)
-- Windows 10, and Windows Server 2012 R2, Windows Server 2016, Windows Server 2022 (AppVeyor and Github Actions)
+- Windows 10, and Windows Server 2012 R2, Windows Server 2016, Windows Server 2022, Windows Server 2025 (AppVeyor and Github Actions)
 - MacOS 10.11 and 11.7 (Travis CI and Github Actions)
 - Valgrind memcheck tool
 
@@ -79,7 +79,7 @@ And the following IDEs/Compilers
 - Clang 5 and 7 (Travis CI)
 - AppleClang 8, 9 and 13 (Travis CI and Github Actions)
 - Xcode 8 & 9 (Travis CI)
-- Visual Studio Community/Entreprise 2022, 2019, 2017, and 2015 (AppVeyor and Github Actions)
+- Visual Studio Community/Entreprise 2026, 2022, 2019, 2017, and 2015 (AppVeyor and Github Actions)
 
 ### Dependencies
 


### PR DESCRIPTION
## Problem

The `windows-latest` GitHub Actions runner migrated to Windows Server 2025 with Visual Studio 2026 (v18) between June 8 and 15, 2026. The "Windows Latest MSVC" CMake job pinned its generator to "Visual Studio 17 2022", which is no longer present on that image, so the configure step failed:

```
CMake Error at CMakeLists.txt:9 (project):
  Generator
    Visual Studio 17 2022
  could not find any instance of Visual Studio.
```

## Fix

- `.github/workflows/cmake.yml`: change the MSVC job generator from "Visual Studio 17 2022" to "Visual Studio 18 2026".
- Update VS 2022 references in `README.md`, `docs/README.md`, `.github/copilot-instructions.md`, and the `sqlitecpp-build-cmake` skill, adding Windows Server 2025 and VS 2026 to the supported lists.

AppVeyor still builds on VS 2022 (and VS 2015), so `appveyor.yml` and the CI workflow skill notes about it are left unchanged.

## Notes

We can decide separately whether to also keep a VS 2022 job by pinning it to `os: windows-2022` (that image is supported for roughly three more years).
