### PR TITLE
Add CI workflow code coverage (GCov + Coveralls)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,55 @@
+name: Coverage
+
+on: [push, pull_request]
+
+jobs:
+  coverage:
+    name: Ubuntu GCC GCov Coverage
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout ${{ github.ref_name }}
+      uses: actions/checkout@v4
+    - run: git submodule update --init --recursive
+
+    - name: Install lcov
+      run: sudo apt-get update && sudo apt-get install -y lcov
+
+    - run: mkdir build
+
+    # Debug build with GCov instrumentation, building both unit tests and the example
+    - name: Configure with GCov instrumentation
+      working-directory: build
+      env:
+        CC: gcc
+        CXX: g++
+      run: cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -DSQLITECPP_USE_GCOV=ON -DSQLITECPP_BUILD_TESTS=ON -DSQLITECPP_BUILD_EXAMPLES=ON -DSQLITECPP_RUN_CPPCHECK=OFF -DSQLITECPP_RUN_CPPLINT=OFF ..
+
+    - name: Build
+      run: cmake --build build --config Debug
+
+    # Run both the unit tests (UnitTests) and the example (Example1Run) to exercise the library
+    - name: Run unit tests and example
+      run: ctest --verbose --output-on-failure --test-dir build
+
+    # Capture coverage of the library only, excluding third-party, tests and examples sources
+    - name: Capture coverage with lcov
+      run: |
+        lcov --capture --directory build --base-directory "$GITHUB_WORKSPACE" \
+             --output-file coverage.info \
+             --rc geninfo_unexecuted_blocks=1 --ignore-errors mismatch,gcov
+        lcov --remove coverage.info \
+             '/usr/*' \
+             "$GITHUB_WORKSPACE/googletest/*" \
+             "$GITHUB_WORKSPACE/sqlite3/*" \
+             "$GITHUB_WORKSPACE/examples/*" \
+             "$GITHUB_WORKSPACE/tests/*" \
+             --output-file coverage.info --ignore-errors unused
+        lcov --list coverage.info
+
+    - name: Publish coverage to Coveralls
+      uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        file: coverage.info
+        format: lcov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,3 +301,4 @@ Version 3.4.0 - 2026 ???
 - Fix the MinGW build by conditionally linking libssp (#527)
 - Add AI coding guidelines for GitHub Copilot and Cursor (#529)
 - Replace the monolithic Copilot instructions with granular agent skills and an AGENTS.md router (#531)
+- Add a GitHub Actions workflow computing unit test & example code coverage (GCov) and publishing it to Coveralls (#549)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SQLiteC++
 [![Travis CI Linux Build Status](https://travis-ci.org/SRombauts/SQLiteCpp.svg?branch=master)](https://travis-ci.org/SRombauts/SQLiteCpp "Travis CI Linux Build Status")
 [![AppVeyor Windows Build status](https://ci.appveyor.com/api/projects/status/github/SRombauts/SQLiteCpp?svg=true)](https://ci.appveyor.com/project/SbastienRombauts/SQLiteCpp "AppVeyor Windows Build status")
 [![GitHub Actions Build status](https://github.com/SRombauts/SQLiteCpp/workflows/build/badge.svg)](https://github.com/SRombauts/SQLiteCpp/actions "GitHhub Actions Build status")
-[![Coveralls](https://img.shields.io/coveralls/SRombauts/SQLiteCpp.svg)](https://coveralls.io/github/SRombauts/SQLiteCpp "Coveralls test coverage")
+[![Coveralls](https://img.shields.io/coveralls/github/SRombauts/SQLiteCpp/master.svg)](https://coveralls.io/github/SRombauts/SQLiteCpp "Coveralls test coverage")
 [![Coverity](https://img.shields.io/coverity/scan/14508.svg)](https://scan.coverity.com/projects/srombauts-sqlitecpp "Coverity Scan Build Status")
 [![Join the chat at https://gitter.im/SRombauts/SQLiteCpp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/SRombauts/SQLiteCpp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ SQLiteC++
 [![Travis CI Linux Build Status](https://travis-ci.org/SRombauts/SQLiteCpp.svg?branch=master)](https://travis-ci.org/SRombauts/SQLiteCpp "Travis CI Linux Build Status")
 [![AppVeyor Windows Build status](https://ci.appveyor.com/api/projects/status/github/SRombauts/SQLiteCpp?svg=true)](https://ci.appveyor.com/project/SbastienRombauts/SQLiteCpp "AppVeyor Windows Build status")
 [![GitHub Actions Build status](https://github.com/SRombauts/SQLiteCpp/workflows/build/badge.svg)](https://github.com/SRombauts/SQLiteCpp/actions "GitHhub Actions Build status")
-[![Coveralls](https://img.shields.io/coveralls/SRombauts/SQLiteCpp.svg)](https://coveralls.io/github/SRombauts/SQLiteCpp "Coveralls test coverage")
+[![Coveralls](https://img.shields.io/coveralls/github/SRombauts/SQLiteCpp/master.svg)](https://coveralls.io/github/SRombauts/SQLiteCpp "Coveralls test coverage")
 [![Coverity](https://img.shields.io/coverity/scan/14508.svg)](https://scan.coverity.com/projects/srombauts-sqlitecpp "Coverity Scan Build Status")
 [![Join the chat at https://gitter.im/SRombauts/SQLiteCpp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/SRombauts/SQLiteCpp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 


### PR DESCRIPTION
Recovered features from Travis CI, stopped since 2023

## Summary

The active GitHub Actions CI builds and runs the unit tests and the example, but it does **not** compute code coverage. Coverage was only ever wired up in the (now defunct) `.travis.yml`, even though the build system still supports it (`SQLITECPP_USE_GCOV` CMake option) and the README still advertises a Coveralls badge.

This PR adds a dedicated `Coverage` workflow that restores coverage reporting on GitHub Actions.

## What it does

- New `.github/workflows/coverage.yml`: a single Linux/GCC job (gcov is GCC-only in `CMakeLists.txt`) that
  - configures with `-DSQLITECPP_USE_GCOV=ON -DSQLITECPP_BUILD_TESTS=ON -DSQLITECPP_BUILD_EXAMPLES=ON`,
  - runs `ctest`, which executes **both** registered tests `UnitTests` and `Example1Run`, so library coverage is driven by the unit tests *and* the example,
  - captures with `lcov`, excluding `/usr`, `googletest`, `sqlite3`, `examples` and `tests` (mirroring the old Travis exclusions),
  - publishes to **Coveralls** via `coverallsapp/github-action@v2`, matching the existing Coveralls badge.

## Notes for review

- Coveralls (not Codecov) was chosen to match the existing badge / project history. Easy to switch if preferred.
- The repo must be enabled on coveralls.io for the upload to appear; the action uses `GITHUB_TOKEN` (no extra secret needed for public repos).
- CHANGELOG entry will be added in a follow-up commit once this PR number is known.