### PR TITLE
Guard null C pointers in Exception, Database, and Statement against UB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,4 +303,5 @@ Version 3.4.0 - 2026 ???
 - Replace the monolithic Copilot instructions with granular agent skills and an AGENTS.md router (#531)
 - Add a GitHub Actions workflow computing unit test & example code coverage (GCov) and publishing it to Coveralls (#549)
 - Add unit tests covering error and edge-case paths to raise code coverage (#551)
+- Guard against null C pointers in Exception, Database, and Statement to avoid undefined behavior (#552)
 - Fix Database::isUnencrypted() to compare the full 16-byte header in binary mode (#553)

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -64,7 +64,7 @@ Database::Database(const char* apFilename,
                    const int   aFlags         /* = SQLite::OPEN_READONLY*/,
                    const int   aBusyTimeoutMs /* = 0 */,
                    const char* apVfs          /* = nullptr*/) :
-    mFilename(apFilename)
+    mFilename(apFilename ? apFilename : "")
 {
     sqlite3* handle;
     const int ret = sqlite3_open_v2(apFilename, &handle, aFlags, apVfs);
@@ -277,7 +277,6 @@ bool Database::isUnencrypted(const std::string& aFilename)
         fileBuffer.seekg(0, std::ios::beg);
         fileBuffer.read(header, 16);
         fileBuffer.close();
-        // A file shorter than the 16-byte header cannot match the magic string.
         if (fileBuffer.gcount() != 16)
         {
             return false;

--- a/src/Exception.cpp
+++ b/src/Exception.cpp
@@ -16,7 +16,7 @@ namespace SQLite
 {
 
 Exception::Exception(const char* aErrorMessage, int ret) :
-    std::runtime_error(aErrorMessage),
+    std::runtime_error(aErrorMessage ? aErrorMessage : ""),
     mErrcode(ret),
     mExtendedErrcode(-1)
 {

--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -286,7 +286,10 @@ int Statement::getColumnIndex(const char* apName) const
         for (int i = 0; i < mColumnCount; ++i)
         {
             const char* pName = sqlite3_column_name(getPreparedStatement(), i);
-            mColumnNames[pName] = i;
+            if (pName)
+            {
+                mColumnNames[pName] = i;
+            }
         }
     }
 
@@ -349,7 +352,7 @@ std::string Statement::getExpandedSQL() const {
     throw SQLite::Exception("this version of SQLiteCpp does not support expanded SQL");
     #else
     char* expanded = sqlite3_expanded_sql(getPreparedStatement());
-    std::string expandedString(expanded);
+    std::string expandedString(expanded ? expanded : "");
     sqlite3_free(expanded);
     return expandedString;
     #endif

--- a/tests/Database_test.cpp
+++ b/tests/Database_test.cpp
@@ -144,6 +144,16 @@ TEST(Database, inMemory)
     } // Close an destroy DB
 }
 
+TEST(Database, nullFilename)
+{
+    // A null filename must not invoke UB in the std::string member; SQLite treats a
+    // null/empty filename as a private, temporary on-disk database.
+    SQLite::Database db(static_cast<const char*>(nullptr), SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
+    EXPECT_STREQ("", db.getFilename().c_str());
+    EXPECT_EQ(0, db.exec("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)"));
+    EXPECT_TRUE(db.tableExists("test"));
+}
+
 TEST(Database, backup)
 {
     // Create a new in-memory database

--- a/tests/Exception_test.cpp
+++ b/tests/Exception_test.cpp
@@ -86,4 +86,11 @@ TEST(Exception, constructor)
         EXPECT_EQ(ex.getExtendedErrorCode(), -1);
         EXPECT_STREQ(ex.getErrorStr(), "unknown error");
     }
+    {
+        // A null message must not be forwarded as-is to std::runtime_error (would be UB)
+        const SQLite::Exception ex(static_cast<const char*>(nullptr), 1);
+        EXPECT_STREQ(ex.what(), "");
+        EXPECT_EQ(ex.getErrorCode(), 1);
+        EXPECT_EQ(ex.getExtendedErrorCode(), -1);
+    }
 }


### PR DESCRIPTION
Fixes a cluster of null C-pointer bugs found in the code review. Each one builds a std::string (or std::runtime_error) from a SQLite C API pointer that can legitimately be null, which is undefined behavior.

- `Statement::getExpandedSQL()` now returns an empty string instead of constructing a `std::string` from a null `sqlite3_expanded_sql()` (null on out of memory, over `SQLITE_LIMIT_LENGTH`, or in `SQLITE_OMIT_TRACE` builds, where it always returns null). Empty is used rather than throwing because this is a diagnostic/logging helper that is often called from error-handling paths, and an `SQLITE_OMIT_TRACE` build would otherwise throw on every call.
- `Statement::getColumnIndex()` skips a null `sqlite3_column_name()` when building the name map.
- `Exception(const char*, int)` falls back to an empty message when passed null.
- `Database(const char*)` falls back to an empty filename when passed null, which matches how SQLite treats a null filename (a private temporary database).

Adds regression tests for the two paths reachable from the public API: a null Exception message and a null Database filename. The two Statement paths need a null from inside SQLite (allocation failure or an OMIT_TRACE build) so they are not unit-testable here; the guards are the fix.
