### PR TITLE
Fix unreliable 16-byte header check in Database::isUnencrypted()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,3 +303,4 @@ Version 3.4.0 - 2026 ???
 - Replace the monolithic Copilot instructions with granular agent skills and an AGENTS.md router (#531)
 - Add a GitHub Actions workflow computing unit test & example code coverage (GCov) and publishing it to Coveralls (#549)
 - Add unit tests covering error and edge-case paths to raise code coverage (#551)
+- Fix Database::isUnencrypted() to compare the full 16-byte header in binary mode (#553)

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -271,19 +271,24 @@ bool Database::isUnencrypted(const std::string& aFilename)
     }
 
     std::ifstream fileBuffer(aFilename.c_str(), std::ios::in | std::ios::binary);
-    char header[16];
+    char header[16] = {};
     if (fileBuffer.is_open())
     {
         fileBuffer.seekg(0, std::ios::beg);
-        fileBuffer.getline(header, 16);
+        fileBuffer.read(header, 16);
         fileBuffer.close();
+        // A file shorter than the 16-byte header cannot match the magic string.
+        if (fileBuffer.gcount() != 16)
+        {
+            return false;
+        }
     }
     else
     {
         throw SQLite::Exception("Error opening file: " + aFilename);
     }
 
-    return strncmp(header, "SQLite format 3\000", 16) == 0;
+    return memcmp(header, "SQLite format 3\000", 16) == 0;
 }
 
 // Parse header data from a database.

--- a/tests/Database_test.cpp
+++ b/tests/Database_test.cpp
@@ -568,6 +568,51 @@ TEST(Database, getHeaderInfo)
     remove("test.db3");
 }
 
+TEST(Database, isUnencryptedHeaderCheck)
+{
+    remove("test.db3");
+    {
+        // Empty filename and non-existent file are reported as errors
+        EXPECT_THROW(SQLite::Database::isUnencrypted(""), SQLite::Exception);
+        EXPECT_THROW(SQLite::Database::isUnencrypted("test.db3"), SQLite::Exception);
+
+        // A real SQLite database file is reported as unencrypted
+        {
+            SQLite::Database db("test.db3", SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
+            db.exec("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)");
+        }
+        EXPECT_TRUE(SQLite::Database::isUnencrypted("test.db3"));
+        remove("test.db3");
+
+        // A file shorter than the 16-byte header must not match and must not crash
+        {
+            const char shortData[] = "SQLite format";  // 13 bytes, no trailing NUL written
+            remove("short.db3");
+            std::ofstream shortDb;
+            shortDb.open("short.db3", std::ios::trunc | std::ios::binary);
+            shortDb.write(shortData, sizeof(shortData) - 1);
+            shortDb.close();
+
+            EXPECT_FALSE(SQLite::Database::isUnencrypted("short.db3"));
+            remove("short.db3");
+        }
+
+        // A 16-byte file with a garbage header does not match the magic string
+        {
+            const char garbage[16] = "garbage header";
+            remove("garbage.db3");
+            std::ofstream garbageDb;
+            garbageDb.open("garbage.db3", std::ios::trunc | std::ios::binary);
+            garbageDb.write(garbage, sizeof(garbage));
+            garbageDb.close();
+
+            EXPECT_FALSE(SQLite::Database::isUnencrypted("garbage.db3"));
+            remove("garbage.db3");
+        }
+    }
+    remove("test.db3");
+}
+
 #ifdef SQLITE_HAS_CODEC
 TEST(Database, encryptAndDecrypt)
 {


### PR DESCRIPTION
isUnencrypted() used ifstream::getline() to read the SQLite magic string, which stops at a newline or NUL and never compares the 16th byte, so the security gate was unreliable and could read uninitialized stack memory on a short file.

- Read exactly 16 raw bytes with read() in binary mode and verify gcount() == 16 (a shorter file returns false instead of comparing garbage), then compare with memcmp, mirroring getHeaderInfo().
- Add a regression test covering a valid database, a too-short file, and a 16-byte garbage header.
