### PR TITLE
Fix stale bindings leaking between execute_many() parameter sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,4 +305,5 @@ Version 3.4.0 - 2026 ???
 - Add unit tests covering error and edge-case paths to raise code coverage (#551)
 - Guard against null C pointers in Exception, Database, and Statement to avoid undefined behavior (#552)
 - Fix Database::isUnencrypted() to compare the full 16-byte header in binary mode (#553)
+- Fix execute_many() to clear stale bindings between parameter sets (#554)
 - Fix Column::operator<< to stream the exact column bytes via getString() (#556)

--- a/include/SQLiteCpp/ExecuteMany.h
+++ b/include/SQLiteCpp/ExecuteMany.h
@@ -54,7 +54,7 @@ void execute_many(Database& aDatabase, const char* apQuery, Arg&& aArg, Types&&.
 }
 
 /**
- * \brief Convenience function to reset a statement and call bind_exec to 
+ * \brief Convenience function to reset a statement and call bind_exec to
  * bind new values to the statement and execute it
  *
  * This feature requires a c++14 capable compiler.
@@ -66,6 +66,7 @@ template <typename TupleT>
 void reset_bind_exec(Statement& apQuery, TupleT&& aTuple)
 {
     apQuery.reset();
+    apQuery.clearBindings();
     bind_exec(apQuery, std::forward<TupleT>(aTuple));
 }
 

--- a/tests/ExecuteMany_test.cpp
+++ b/tests/ExecuteMany_test.cpp
@@ -51,4 +51,44 @@ TEST(ExecuteMany, invalid)
         EXPECT_EQ(std::make_pair(3,std::string{"three"}), results.at(2));
     }
 }
+
+TEST(ExecuteMany, decreasingArity)
+{
+    // Create a new database
+    SQLite::Database db(":memory:", SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
+
+    EXPECT_EQ(0, db.exec("DROP TABLE IF EXISTS test"));
+    EXPECT_EQ(0, db.exec("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)"));
+    EXPECT_TRUE(db.tableExists("test"));
+    {
+        // The first row binds both parameters, the second row binds only the id
+        // and leaves the value parameter unbound: it must be stored as NULL, not
+        // reuse the "first" value left over from the previous parameter set.
+        execute_many(db, "INSERT INTO test VALUES (?, ?)",
+            std::make_tuple(1, "first"),
+            std::make_tuple(2)
+        );
+    }
+    // make sure the stale binding did not leak into the second row
+    {
+        SQLite::Statement query(db, std::string{"SELECT id, value FROM test ORDER BY id"});
+        std::vector<std::pair<int, std::string> > results;
+        std::vector<bool> valueIsNull;
+        while (query.executeStep())
+        {
+            const int id = query.getColumn(0);
+            valueIsNull.push_back(query.getColumn(1).isNull());
+            std::string value = query.getColumn(1);
+            results.emplace_back( id, std::move(value) );
+        }
+        EXPECT_EQ(std::size_t(2), results.size());
+
+        EXPECT_EQ(std::make_pair(1,std::string{"first"}), results.at(0));
+        EXPECT_FALSE(valueIsNull.at(0));
+
+        // Without clearBindings() the second row would wrongly store "first"
+        EXPECT_EQ(2, results.at(1).first);
+        EXPECT_TRUE(valueIsNull.at(1));
+    }
+}
 #endif // c++14


### PR DESCRIPTION
execute_many() reset the statement between parameter sets but never cleared the bindings, so a set that bound fewer values than the previous one silently reused the leftover values (silent data corruption). Call clearBindings() after reset() so each parameter set starts clean.

Adds a regression test covering decreasing arity across parameter sets.
