### PR TITLE
Fix Column::operator<< to stream the exact column bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,3 +305,4 @@ Version 3.4.0 - 2026 ???
 - Add unit tests covering error and edge-case paths to raise code coverage (#551)
 - Guard against null C pointers in Exception, Database, and Statement to avoid undefined behavior (#552)
 - Fix Database::isUnencrypted() to compare the full 16-byte header in binary mode (#553)
+- Fix Column::operator<< to stream the exact column bytes via getString() (#556)

--- a/src/Column.cpp
+++ b/src/Column.cpp
@@ -116,7 +116,8 @@ int Column::getBytes() const noexcept
 // Standard std::ostream inserter
 std::ostream& operator<<(std::ostream& aStream, const Column& aColumn)
 {
-    aStream.write(aColumn.getText(), aColumn.getBytes());
+    const std::string value = aColumn.getString();
+    aStream.write(value.data(), static_cast<std::streamsize>(value.size()));
     return aStream;
 }
 

--- a/tests/Column_test.cpp
+++ b/tests/Column_test.cpp
@@ -262,6 +262,87 @@ TEST(Column, stream)
     EXPECT_EQ(content, str);
 }
 
+// COL-01 probe: try to break operator<< with multibyte UTF-8 TEXT.
+// Bytes are written with \x escapes so the test does not depend on the source file encoding.
+TEST(Column, streamUtf8Text)
+{
+    SQLite::Database db(":memory:", SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
+    EXPECT_EQ(0, db.exec("CREATE TABLE test (msg TEXT)"));
+    SQLite::Statement insert(db, "INSERT INTO test VALUES (?)");
+
+    const std::string utf8 =
+        "caf\xC3\xA9"               // cafe with e-acute (U+00E9)
+        " \xE4\xB8\x96\xE7\x95\x8C"  // CJK "world" (U+4E16 U+754C)
+        " \xF0\x9F\x98\x80";         // grinning face emoji (U+1F600)
+
+    insert.bind(1, utf8);
+    EXPECT_EQ(1, insert.exec());
+
+    SQLite::Statement query(db, "SELECT msg FROM test");
+    ASSERT_TRUE(query.executeStep());
+
+    std::stringstream ss;
+    ss << query.getColumn(0);
+    const std::string streamed = ss.str();
+
+    // operator<< must reproduce the exact UTF-8 byte sequence and agree with getString()
+    EXPECT_EQ(streamed.size(), utf8.size());
+    EXPECT_EQ(streamed, utf8);
+    EXPECT_EQ(streamed, query.getColumn(0).getString());
+}
+
+// COL-01 probe: multibyte UTF-8 TEXT on both sides of an embedded NUL byte.
+TEST(Column, streamUtf8EmbeddedNul)
+{
+    SQLite::Database db(":memory:", SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
+    EXPECT_EQ(0, db.exec("CREATE TABLE test (msg TEXT)"));
+    SQLite::Statement insert(db, "INSERT INTO test VALUES (?)");
+
+    const char raw[] = "caf\xC3\xA9\x00\xF0\x9F\x98\x80"; // "cafe" + NUL + emoji
+    const std::string utf8(raw, sizeof(raw) - 1);         // keep the embedded NUL, drop the literal terminator
+
+    insert.bind(1, utf8);
+    EXPECT_EQ(1, insert.exec());
+
+    SQLite::Statement query(db, "SELECT msg FROM test");
+    ASSERT_TRUE(query.executeStep());
+
+    std::stringstream ss;
+    ss << query.getColumn(0);
+    const std::string streamed = ss.str();
+
+    EXPECT_EQ(streamed.size(), utf8.size());
+    EXPECT_EQ(streamed, utf8);
+}
+
+// COL-01 probe: the same UTF-8 bytes stored as a BLOB (the case the review flags).
+TEST(Column, streamUtf8Blob)
+{
+    SQLite::Database db(":memory:", SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
+    EXPECT_EQ(0, db.exec("CREATE TABLE test (data BLOB)"));
+    SQLite::Statement insert(db, "INSERT INTO test VALUES (?)");
+
+    const std::string utf8 =
+        "caf\xC3\xA9"
+        " \xE4\xB8\x96\xE7\x95\x8C"
+        " \xF0\x9F\x98\x80";
+
+    insert.bind(1, utf8.data(), static_cast<int>(utf8.size())); // store as a BLOB
+    EXPECT_EQ(1, insert.exec());
+
+    SQLite::Statement query(db, "SELECT data FROM test");
+    ASSERT_TRUE(query.executeStep());
+    EXPECT_TRUE(query.getColumn(0).isBlob());
+
+    std::stringstream ss;
+    ss << query.getColumn(0);
+    const std::string streamed = ss.str();
+
+    EXPECT_EQ(streamed.size(), utf8.size());
+    EXPECT_EQ(streamed, utf8);
+    EXPECT_EQ(streamed, query.getColumn(0).getString());
+}
+
 TEST(Column, shared_ptr)
 {
     // Create a new database


### PR DESCRIPTION
Fixes COL-01 from the code review. `Column::operator<<` passed `getText()` and `getBytes()` as two separate call arguments: their evaluation order is unspecified, and the two SQLite accessors have an order-dependent contract (the text pointer can be invalidated by a later bytes call). Reading the value once through `getString()` pairs the pointer with its length and behaves consistently for TEXT, BLOB, embedded NULs and NULL.

Adds UTF-8 regression tests for the stream inserter (multibyte text, an embedded NUL, and the same bytes stored as a BLOB). Note these pass against the old code too on GCC, since for TEXT/BLOB the accessors happen to be idempotent; the fix is about removing the unspecified-order UB and honoring SQLite's call-order contract.
