### PR TITLE
Restore Coverity Scan static analysis as a GitHub Actions workflow

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,41 @@
+name: Coverity Scan
+
+# Coverity Scan static analysis. The action needs the secret project token,
+# which forks cannot read, so this runs only on pushes to master in the
+# upstream repository, plus manual dispatch.
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  coverity:
+    name: Ubuntu GCC Coverity Scan
+    runs-on: ubuntu-24.04
+    if: github.repository == 'SRombauts/SQLiteCpp'
+
+    steps:
+    - name: Checkout ${{ github.ref_name }}
+      uses: actions/checkout@v4
+    - run: git submodule update --init --recursive
+
+    - run: mkdir build
+
+    # Configure before Coverity wraps the compilation. The analysis only needs
+    # the library to compile, so the tests and examples are left out.
+    - name: Configure
+      working-directory: build
+      env:
+        CC: gcc
+        CXX: g++
+      run: cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -DSQLITECPP_BUILD_TESTS=OFF -DSQLITECPP_BUILD_EXAMPLES=OFF -DSQLITECPP_RUN_CPPCHECK=OFF -DSQLITECPP_RUN_CPPLINT=OFF ..
+
+    # Download the Coverity build tool, run the build through cov-build, then
+    # upload the result to https://scan.coverity.com/projects/srombauts-sqlitecpp
+    - name: Coverity Scan
+      uses: vapier/coverity-scan-action@v1
+      with:
+        project: SRombauts/SQLiteCpp
+        email: sebastien.rombauts@gmail.com
+        token: ${{ secrets.COVERITY_SCAN_TOKEN }}
+        command: cmake --build build --config Debug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,3 +306,4 @@ Version 3.4.0 - 2026 ???
 - Guard against null C pointers in Exception, Database, and Statement to avoid undefined behavior (#552)
 - Fix Database::isUnencrypted() to compare the full 16-byte header in binary mode (#553)
 - Fix Column::operator<< to stream the exact column bytes via getString() (#556)
+- Restore the Coverity Scan static analysis as a GitHub Actions workflow, replacing the old Travis CI job


### PR DESCRIPTION
## What this does

The Coverity Scan static analysis used to run from the Travis CI build matrix (the `COVERITY_SCAN_*` job in `.travis.yml`). Travis is gone, so the analysis stopped running even though the Coverity project at https://scan.coverity.com/projects/srombauts-sqlitecpp and its README badge are still there.

This adds a dedicated GitHub Actions workflow (`.github/workflows/coverity.yml`) that brings it back. It uses the official `vapier/coverity-scan-action`, which downloads the Coverity build tool, compiles the library through `cov-build`, and uploads the result to the same project.

## How it runs

- On pushes to `master` and on manual `workflow_dispatch`.
- Only in the upstream `SRombauts/SQLiteCpp` repository, guarded by an `if` on `github.repository`, because the secret token is not readable from forks.
- The build is configured with tests and examples off, since the analysis only needs the library to compile.

## One setup step before it works

The workflow reads the project token from a repository secret named `COVERITY_SCAN_TOKEN`. The old Travis job stored the same token encrypted in `.travis.yml`, so that ciphertext cannot be reused here.

To enable the workflow, add the token under **Settings -> Secrets and variables -> Actions -> New repository secret**:

- Name: `COVERITY_SCAN_TOKEN`
- Value: the project token from the Coverity **Project Settings** tab.

The notification email is set to `sebastien.rombauts@gmail.com` in the workflow, matching the old Travis config. Until the secret is added, the job fails at the upload step with an authentication error and nothing else is affected.

## Notes

- `.travis.yml` is left untouched; this PR only adds the GitHub Actions equivalent.
- Added a CHANGELOG entry under the open 3.4.0 section.
