### PR TITLE
Fix Savepoint destructor exception-safety and rollback bookkeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,3 +309,4 @@ Version 3.4.0 - 2026 ???
 - Fix Column::operator<< to stream the exact column bytes via getString() (#556)
 - Restore the Coverity Scan static analysis as a GitHub Actions workflow, replacing the old Travis CI job
 - Fix Database::getHeaderInfo() signed-shift UB and use fixed-width types for the Header struct (#558)
+- Fix Savepoint destructor to catch all exceptions and track rollback state to avoid std::terminate (#559)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,3 +310,4 @@ Version 3.4.0 - 2026 ???
 - Restore the Coverity Scan static analysis as a GitHub Actions workflow, replacing the old Travis CI job
 - Fix Database::getHeaderInfo() signed-shift UB and use fixed-width types for the Header struct (#558)
 - Fix Savepoint destructor to catch all exceptions and track rollback state to avoid std::terminate (#559)
+- Fix Transaction destructor to catch all exceptions to avoid std::terminate (#559)

--- a/include/SQLiteCpp/Savepoint.h
+++ b/include/SQLiteCpp/Savepoint.h
@@ -90,9 +90,10 @@ public:
     void rollback() { rollbackTo(); }
 
 private:
-    Database&   mDatabase;          ///< Reference to the SQLite Database Connection
-    std::string msName;             ///< Name of the Savepoint
-    bool        mbReleased = false; ///< True when release has been called
+    Database&   mDatabase;            ///< Reference to the SQLite Database Connection
+    std::string msName;               ///< Name of the Savepoint
+    bool        mbReleased = false;   ///< True when release has been called
+    bool        mbRolledBack = false; ///< True when a rollback to the savepoint has been done
 };
 
 }  // namespace SQLite

--- a/src/Savepoint.cpp
+++ b/src/Savepoint.cpp
@@ -40,10 +40,13 @@ Savepoint::~Savepoint()
     {
         try
         {
-            rollback();
+            if (!mbRolledBack)
+            {
+                rollbackTo();
+            }
             release();
         }
-        catch (SQLite::Exception&)
+        catch (...)
         {
             // Never throw an exception in a destructor: error if already released,
             // but no harm is caused by this.
@@ -71,6 +74,7 @@ void Savepoint::rollbackTo()
     if (!mbReleased)
     {
         mDatabase.exec(std::string("ROLLBACK TO SAVEPOINT ") + msName);
+        mbRolledBack = true;
     }
     else
     {

--- a/src/Transaction.cpp
+++ b/src/Transaction.cpp
@@ -55,7 +55,7 @@ Transaction::~Transaction()
         {
             mDatabase.exec("ROLLBACK TRANSACTION");
         }
-        catch (SQLite::Exception&)
+        catch (...)
         {
             // Never throw an exception in a destructor: error if already rollbacked, but no harm is caused by this.
         }

--- a/tests/Savepoint_test.cpp
+++ b/tests/Savepoint_test.cpp
@@ -105,6 +105,31 @@ TEST(Savepoint, commitRollback)
     EXPECT_EQ(1, nbRows);
 }
 
+TEST(Savepoint, rollbackToThenRelease)
+{
+    // Create a new database
+    SQLite::Database db(":memory:", SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
+    EXPECT_EQ(SQLite::OK, db.getErrorCode());
+    db.exec("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)");
+
+    {
+        SQLite::Savepoint savepoint(db, "sp");
+
+        EXPECT_EQ(1, db.exec("INSERT INTO test VALUES (NULL, 'rolled back')"));
+
+        // A manual rollback leaves the savepoint on the stack, so releasing it afterwards succeeds.
+        savepoint.rollbackTo();
+        EXPECT_NO_THROW(savepoint.release());
+
+        // end of scope: already released, the destructor must do nothing and not throw
+    }
+
+    // The rolled-back insert must not be persisted
+    SQLite::Statement query(db, "SELECT COUNT(*) FROM test");
+    ASSERT_TRUE(query.executeStep());
+    EXPECT_EQ(0, query.getColumn(0).getInt());
+}
+
 TEST(Savepoint, destructorSwallowsException)
 {
     // Create a new database


### PR DESCRIPTION
## Summary

Fixes two findings from the deep code review (SP-03, SP-02) in the `Savepoint` destructor. The documented auto-rollback-on-scope-exit semantics are unchanged.

### SP-03 — destructor could call `std::terminate`
`~Savepoint()` caught only `SQLite::Exception`. Building the `"ROLLBACK TO SAVEPOINT " + msName` / `"RELEASE SAVEPOINT " + msName` strings can throw `std::bad_alloc`, and any non-`SQLite::Exception` thrown during cleanup would escape the implicitly `noexcept` destructor and terminate the process. The handler is now `catch (...)`, matching the stated intent ("Never throw an exception in a destructor").

### SP-02 — no rolled-back state, fragile double-rollback
There was a single `mbReleased` flag and no notion of "already rolled back", so after a manual `rollbackTo()` (or on the normal scope-exit path) the destructor issued a `ROLLBACK TO` and then a `RELEASE`, relying on SQLite tolerating a repeated `ROLLBACK TO`. A new `mbRolledBack` flag (set in `rollbackTo()`) lets the destructor do the minimum: skip the redundant `ROLLBACK TO` and just `RELEASE`.

## Test plan
- Added `Savepoint.rollbackToThenRelease` covering a manual `rollbackTo()` followed by `release()` and a clean scope exit.
- Built `SQLiteCpp_tests` (MSVC, Debug); `ctest -C Debug` 100% passed, including the existing `Savepoint.commitRollback` and `Savepoint.destructorSwallowsException` tests.

No public API or behavioural change on the happy path; only the (previously UB-on-OOM) destructor error handling and the redundant-command path change.
