### PR TITLE
Fix broken Meson build when SQLITECPP_DISABLE_STD_FILESYSTEM is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,3 +311,4 @@ Version 3.4.0 - 2026 ???
 - Fix Database::getHeaderInfo() signed-shift UB and use fixed-width types for the Header struct (#558)
 - Fix Savepoint destructor to catch all exceptions and track rollback state to avoid std::terminate (#559)
 - Fix Transaction destructor to catch all exceptions to avoid std::terminate (#559)
+- Fix the Meson build when the SQLITECPP_DISABLE_STD_FILESYSTEM option is enabled (#560)

--- a/meson.build
+++ b/meson.build
@@ -129,7 +129,7 @@ endif
 
 ## C++17 disable the support for std::filesystem (by default off)
 if get_option('SQLITECPP_DISABLE_STD_FILESYSTEM')
-    sqlitecpp_cxx_flags += ['-DSQLITECPP_DISABLE_STD_FILESYSTEM']
+    sqlitecpp_args += ['-DSQLITECPP_DISABLE_STD_FILESYSTEM']
 endif
 
 ## get the user option for the SQLITECPP_DISABLE_SQLITE3_EXPANDED_SQL


### PR DESCRIPTION
Enabling the `SQLITECPP_DISABLE_STD_FILESYSTEM` Meson option appended to an undefined `sqlitecpp_cxx_flags` variable, so the configure step erred out instead of defining the macro. Append to `sqlitecpp_args`, matching every other option branch, so the flag reaches the compiler.
