### PR TITLE
Streamline AppVeyor builds

### DIFF
--- a/.claude/skills/sqlitecpp-ci-workflows/SKILL.md
+++ b/.claude/skills/sqlitecpp-ci-workflows/SKILL.md
@@ -30,9 +30,11 @@ description: SQLiteCpp CI workflow patterns. Use for GitHub Actions, AppVeyor, T
 - Test: `meson test -C builddir`.
 
 ## AppVeyor
-- Visual Studio 2022/2015, Debug/Release, Win32/x64.
+- Visual Studio 2022/2019, Release, Win32/x64. GitHub Actions provides the overlapping Debug coverage.
 - CMake config: `-DSQLITECPP_BUILD_EXAMPLES=ON -DSQLITECPP_BUILD_TESTS=ON -DSQLITECPP_RUN_CPPCHECK=OFF`.
 - Build and run `ctest --output-on-failure`.
+- Configure `branches.only: master` in `appveyor.yml`; its presence overrides branch filtering from the AppVeyor
+  project UI. Pull requests targeting `master` are still built, while pushes to task branches are skipped.
 
 ## Travis CI
 - Multiple GCC/Clang versions across Linux and macOS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -316,3 +316,4 @@ Version 3.4.0 - 2026 ???
 - Add unit tests for Statement::RowIterator to fix coverage regression (#562)
 - Fix large `std::string` binding sizes (#563)
 - Add 64-bit BLOB binding methods (#564)
+- Limit AppVeyor to Visual Studio 2022 and 2019 Release builds on master and pull requests (#565)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,20 +3,21 @@
 # build format
 version: "{build}"
 
+# Build the master branch and pull requests targeting master, but not pushes to task branches.
+branches:
+  only:
+    - master
+
 # scripts that run after cloning repository
 install:
   - git submodule update --init --recursive
  
 image:
-# Note: reduced the number of images to test on AppVeyor, to speed up the build
   - Visual Studio 2022
-#  - Visual Studio 2019
-#  - Visual Studio 2017
-  - Visual Studio 2015
-  
-# configurations to add to build matrix
+  - Visual Studio 2019
+
+# GitHub Actions covers Debug builds; AppVeyor tests Release builds on supported Visual Studio versions.
 configuration:
-  - Debug
   - Release
 
 environment:
@@ -26,12 +27,8 @@ environment:
 
 init:
   - echo %APPVEYOR_BUILD_WORKER_IMAGE% - %configuration% - %arch%
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" (set vs=Visual Studio 15 2017)
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" (set vs=Visual Studio 14 2015)
-  - if "%arch%"=="x64" (set generator="%vs% Win64") else (set generator="%vs%")
-  # CMake uses a different grammar for Visual Studio 2019, with -A to specify architecture:
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" (set generator="Visual Studio 16 2019" -A %arch%)
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2022" (set generator="Visual Studio 17 2022" -A %arch%)
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" (set generator="Visual Studio 16 2019" -A %arch%)
   - echo %generator%
  
 # scripts to run before build


### PR DESCRIPTION
Reduce AppVeyor to supported Visual Studio 2022 and 2019 Release builds on Win32 and x64. Restrict branch pushes to master so pull requests run one four-job AppVeyor matrix instead of duplicate branch and PR matrices.